### PR TITLE
Add Power page and align history range filters

### DIFF
--- a/src-tauri/src/server/api.rs
+++ b/src-tauri/src/server/api.rs
@@ -801,17 +801,19 @@ pub async fn sync_clock(State(state): State<Arc<AppState>>) -> (StatusCode, Json
 
 #[derive(Debug, Deserialize)]
 pub struct HistoryQuery {
-    /// Time range shorthand: "1h", "6h", "24h", "7d", "30d", "6m", "1y"
+    /// Time range shorthand: "1h", "6h", "12h", "24h", "today", "7d", "30d", "6m", "1y"
     pub range: Option<String>,
     /// Comma-separated field names
     pub fields: Option<String>,
     /// Number of windows to page back (default 0)
     pub offset: Option<i64>,
+    /// Use a rolling [now - range, now] window instead of an aligned bucket.
+    pub rolling: Option<bool>,
 }
 
 /// GET /api/history — aggregated time-series data for charts.
 ///
-/// Query params: `range`, `fields`, `offset`.
+/// Query params: `range`, `fields`, `offset`, `rolling`.
 /// Returns `{ok: true, data: {field: [{t, v}, ...]}}`.
 pub async fn get_history(
     State(state): State<Arc<AppState>>,
@@ -820,20 +822,43 @@ pub async fn get_history(
     let range_str = params.range.as_deref().unwrap_or("24h");
     let fields_str = params.fields.as_deref().unwrap_or("soc");
     let offset = params.offset.unwrap_or(0);
+    let rolling = params.rolling.unwrap_or(false);
 
     let (range_secs, bucket_secs) = match range_str {
         "1h" => (3600, 30),
         "6h" => (3600 * 6, 60),
+        "12h" => (3600 * 12, 120),
         "24h" => (86400, 300),
+        "today" => (86400, 300),
         "7d" => (86400 * 7, 1800),
         "30d" => (86400 * 30, 7200),
         "6m" => (86400 * 180, 43200),
         "1y" => (86400 * 365, 86400),
         "month" => (0, 3600), // calendar month — uses explicit window
-        _ => return error_response("Invalid range. Use: 1h, 6h, 24h, 7d, 30d, 6m, 1y, month"),
+        _ => return error_response("Invalid range. Use: 1h, 6h, 12h, 24h, today, 7d, 30d, 6m, 1y, month"),
     };
 
-    let explicit_window: Option<(i64, i64)> = if range_str == "month" {
+    let explicit_window: Option<(i64, i64)> = if rolling && range_str != "month" && range_str != "today" {
+        let end_ts = chrono::Utc::now().timestamp() - offset * range_secs;
+        Some((end_ts - range_secs, end_ts))
+    } else if range_str == "today" {
+        let now = chrono::Local::now();
+        let start_date = now.date_naive() - chrono::Duration::days(offset);
+        let start_local = start_date.and_hms_opt(0, 0, 0).unwrap();
+        let start_local_dt = chrono::Local
+            .from_local_datetime(&start_local)
+            .earliest()
+            .unwrap();
+        let end_date = start_date.succ_opt().unwrap();
+        let end_local = end_date.and_hms_opt(0, 0, 0).unwrap();
+        let end_ts = chrono::Local
+            .from_local_datetime(&end_local)
+            .earliest()
+            .unwrap()
+            .timestamp();
+
+        Some((start_local_dt.timestamp(), end_ts))
+    } else if range_str == "month" {
         // Compute calendar month boundaries in local time.
         let now = chrono::Local::now();
         // Apply offset (month offset, since month windows have variable length)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import HistoryPage from './pages/HistoryPage';
 import LogsPage from './pages/LogsPage';
 import SolarPage from './pages/SolarPage';
 import InverterPage from './pages/InverterPage';
+import PowerPage from './pages/PowerPage';
 import ErrorBoundary from './components/ErrorBoundary';
 
 function ThemeToggle() {
@@ -50,6 +51,7 @@ function ConnectionIndicator() {
 
 const NAV_ITEMS = [
   { to: '/', label: 'Status', icon: StatusIcon },
+  { to: '/power', label: 'Power', icon: PowerIcon },
   { to: '/battery', label: 'Battery', icon: BatteryIcon },
   { to: '/inverter', label: 'Inverter', icon: InverterIcon },
   { to: '/solar', label: 'Solar', icon: SolarIcon },
@@ -71,6 +73,14 @@ function HistoryIcon() {
   return (
     <svg className="w-7 h-7 sm:w-5 sm:h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  );
+}
+
+function PowerIcon() {
+  return (
+    <svg className="w-4 h-4 sm:w-5 sm:h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13 2L4 14h7l-1 8 10-13h-7V2z" />
     </svg>
   );
 }
@@ -168,6 +178,7 @@ function Layout() {
       <main className="flex-1 overflow-auto px-4 py-6 md:px-6 md:py-8">
         <Routes>
           <Route path="/" element={<ErrorBoundary><StatusPage /></ErrorBoundary>} />
+          <Route path="/power" element={<ErrorBoundary><PowerPage /></ErrorBoundary>} />
           <Route path="/battery" element={<ErrorBoundary><BatteryPage /></ErrorBoundary>} />
           <Route path="/history" element={<ErrorBoundary><HistoryPage /></ErrorBoundary>} />
           <Route path="/control" element={<ErrorBoundary><ControlPage /></ErrorBoundary>} />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -87,12 +87,16 @@ export async function fetchHistory(
   range: string,
   fields: string[],
   offset: number = 0,
+  rolling: boolean = false,
 ): Promise<Record<string, Array<{ t: number; v: number }>>> {
   const params = new URLSearchParams({
     range,
     fields: fields.join(','),
     offset: String(offset),
   });
+  if (rolling) {
+    params.set('rolling', 'true');
+  }
   const res = await apiGet<{ ok: boolean; data: Record<string, Array<{ t: number; v: number }>> }>(
     `/api/history?${params}`,
   );

--- a/src/lib/historyRangeConfig.ts
+++ b/src/lib/historyRangeConfig.ts
@@ -1,0 +1,200 @@
+import type { HistoryRange } from './types';
+
+export const HISTORY_RANGES: { key: HistoryRange; label: string }[] = [
+  { key: '1h', label: '1h' },
+  { key: '6h', label: '6h' },
+  { key: '12h', label: '12h' },
+  { key: '24h', label: '24h' },
+  { key: 'today', label: 'Today' },
+  { key: '7d', label: '7d' },
+  { key: '30d', label: '30d' },
+  { key: 'month', label: 'Month' },
+  { key: '6m', label: '6m' },
+  { key: '1y', label: '1y' },
+];
+
+export const HISTORY_CHART_GRID_PROPS = {
+  strokeDasharray: '4 4',
+  stroke: 'var(--color-grid-stroke)',
+  strokeWidth: 2,
+} as const;
+
+export const HISTORY_RANGE_MS: Partial<Record<HistoryRange, number>> = {
+  '1h': 3600000,
+  '6h': 21600000,
+  '12h': 43200000,
+  '24h': 86400000,
+  '7d': 604800000,
+  '30d': 2592000000,
+  '6m': 15552000000,
+  '1y': 31536000000,
+};
+
+export function isRollingHistoryRange(range: HistoryRange): boolean {
+  return range !== 'month' && range !== 'today';
+}
+
+export function shouldRefreshHistoryRange(range: HistoryRange, offset: number = 0): boolean {
+  return isRollingHistoryRange(range) || (range === 'today' && offset === 0);
+}
+
+export function shouldTrimHistoryRangeLeadingGap(range: HistoryRange): boolean {
+  return range === '1h' || range === '6h';
+}
+
+export function getTodayBoundaryMs(offset: number, nowMs: number = Date.now()): [number, number] {
+  const now = new Date(nowMs);
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - offset, 0, 0, 0, 0).getTime();
+  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() - offset + 1, 0, 0, 0, 0).getTime();
+  return [start, end];
+}
+
+export function getMonthBoundaryMs(offset: number, nowMs: number = Date.now()): [number, number] {
+  const now = new Date(nowMs);
+  const totalMonths = now.getFullYear() * 12 + now.getMonth() - offset;
+  const targetYear = Math.floor(totalMonths / 12);
+  const targetMonth = totalMonths % 12;
+  return [
+    new Date(targetYear, targetMonth, 1, 0, 0, 0, 0).getTime(),
+    new Date(targetYear, targetMonth + 1, 1, 0, 0, 0, 0).getTime(),
+  ];
+}
+
+export function getHistoryRangeDomain(
+  range: HistoryRange,
+  offset: number = 0,
+  nowMs: number = Date.now(),
+): [number, number] {
+  if (range === 'today') {
+    return getTodayBoundaryMs(offset, nowMs);
+  }
+
+  if (range === 'month') {
+    return getMonthBoundaryMs(offset, nowMs);
+  }
+
+  const windowMs = HISTORY_RANGE_MS[range] ?? HISTORY_RANGE_MS['24h'] ?? 86400000;
+  const end = nowMs - offset * windowMs;
+  return [end - windowMs, end];
+}
+
+export function getHistoryXAxisTicks(
+  range: HistoryRange,
+  domain: [number, number],
+): number[] | undefined {
+  const startMs = domain[0];
+  const endMs = domain[1];
+  const spanMs = endMs - startMs;
+  const startDate = new Date(startMs);
+
+  if (range === '1h') {
+    const ticks: number[] = [];
+    const cursor = new Date(startDate);
+    cursor.setMinutes(0, 0, 0);
+    while (cursor.getTime() < startMs) cursor.setMinutes(cursor.getMinutes() + 10);
+    while (cursor.getTime() < endMs) {
+      ticks.push(cursor.getTime());
+      cursor.setMinutes(cursor.getMinutes() + 10);
+    }
+    return ticks;
+  }
+
+  if (range === '6h') {
+    const ticks: number[] = [];
+    const cursor = new Date(startDate);
+    cursor.setMinutes(0, 0, 0);
+    while (cursor.getTime() < startMs) cursor.setHours(cursor.getHours() + 1);
+    while (cursor.getTime() < endMs) {
+      ticks.push(cursor.getTime());
+      cursor.setHours(cursor.getHours() + 1);
+    }
+    return ticks;
+  }
+
+  if (range === '12h') {
+    const ticks: number[] = [];
+    const cursor = new Date(startDate);
+    cursor.setMinutes(0, 0, 0);
+    while (cursor.getTime() < startMs) cursor.setHours(cursor.getHours() + 2);
+    while (cursor.getTime() < endMs) {
+      ticks.push(cursor.getTime());
+      cursor.setHours(cursor.getHours() + 2);
+    }
+    return ticks;
+  }
+
+  if (range === '24h' || range === 'today') {
+    const ticks: number[] = [];
+    const cursor = new Date(startDate);
+    cursor.setMinutes(0, 0, 0);
+    while (cursor.getTime() < startMs) cursor.setHours(cursor.getHours() + 3);
+    while (cursor.getTime() < endMs) {
+      ticks.push(cursor.getTime());
+      cursor.setHours(cursor.getHours() + 3);
+    }
+    return ticks;
+  }
+
+  if (range === '6m' || range === '1y') {
+    const approxMonths = Math.max(1, Math.round(spanMs / (30 * 86400000)));
+    const stepMonths = Math.max(1, Math.floor(approxMonths / 6));
+    const ticks: number[] = [];
+    const cursor = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
+    while (cursor.getTime() < startMs) cursor.setMonth(cursor.getMonth() + stepMonths);
+    while (cursor.getTime() < endMs) {
+      ticks.push(cursor.getTime());
+      cursor.setMonth(cursor.getMonth() + stepMonths);
+    }
+    return ticks;
+  }
+
+  const totalDays = spanMs / 86400000;
+  const step = Math.max(1, Math.floor(totalDays / 6));
+  const ticks: number[] = [];
+  const cursor = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+  while (cursor.getTime() < startMs) cursor.setDate(cursor.getDate() + step);
+  while (cursor.getTime() < endMs) {
+    ticks.push(cursor.getTime());
+    cursor.setDate(cursor.getDate() + step);
+  }
+  return ticks;
+}
+
+export function formatHistoryXAxisTick(ts: number, range: HistoryRange): string {
+  const d = new Date(ts);
+  if (range === '1h' || range === '6h' || range === '12h' || range === '24h' || range === 'today') {
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+  if (range === '7d' || range === '30d') {
+    return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  }
+  if (range === 'month') {
+    return String(d.getDate());
+  }
+  return d.toLocaleDateString([], { month: 'short', year: 'numeric' });
+}
+
+export function getHistoryXAxisMinTickGap(range: HistoryRange): number {
+  return range === '1h' || range === '6h' || range === '12h' || range === '24h' || range === 'today'
+    ? 30
+    : 40;
+}
+
+export function trimDomainStartToFirstDataPoint<T extends { t: number }>(
+  domain: [number, number],
+  series: Record<string, T[]>,
+  minGapMs: number = 60000,
+): [number, number] {
+  let firstTs = Infinity;
+  for (const points of Object.values(series)) {
+    if (points.length > 0 && points[0].t < firstTs) {
+      firstTs = points[0].t;
+    }
+  }
+
+  if (firstTs === Infinity || firstTs >= domain[1]) {
+    return domain;
+  }
+
+  return firstTs - domain[0] > minGapMs ? [firstTs, domain[1]] : domain;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -152,4 +152,4 @@ export interface TimePoint {
   v: number;
 }
 
-export type HistoryRange = '1h' | '6h' | '24h' | '7d' | '30d' | '6m' | '1y' | 'month';
+export type HistoryRange = '1h' | '6h' | '12h' | '24h' | 'today' | '7d' | '30d' | 'month' | '6m' | '1y';

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -9,6 +9,19 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { fetchHistory, apiGet, isTauri } from '../lib/api';
+import {
+  HISTORY_CHART_GRID_PROPS,
+  HISTORY_RANGES,
+  HISTORY_RANGE_MS,
+  getHistoryRangeDomain,
+  getHistoryXAxisMinTickGap,
+  getHistoryXAxisTicks,
+  formatHistoryXAxisTick,
+  isRollingHistoryRange,
+  shouldRefreshHistoryRange,
+  shouldTrimHistoryRangeLeadingGap,
+  trimDomainStartToFirstDataPoint,
+} from '../lib/historyRangeConfig';
 import type { HistoryRange, PollSettings, TariffConfig } from '../lib/types';
 
 // ---------------------------------------------------------------------------
@@ -89,17 +102,6 @@ function removeSpikes(points: TimePoint[], field: string): TimePoint[] {
 // Constants
 // ---------------------------------------------------------------------------
 
-const RANGES: { key: HistoryRange; label: string }[] = [
-  { key: '1h', label: '1h' },
-  { key: '6h', label: '6h' },
-  { key: '24h', label: '24h' },
-  { key: '7d', label: '7d' },
-  { key: '30d', label: '30d' },
-  { key: 'month', label: 'Month' },
-  { key: '6m', label: '6m' },
-  { key: '1y', label: '1y' },
-];
-
 const TABS: { key: MetricTab; label: string }[] = [
   { key: 'battery', label: 'Battery' },
   { key: 'solar', label: 'Solar' },
@@ -107,44 +109,6 @@ const TABS: { key: MetricTab; label: string }[] = [
   { key: 'home', label: 'Home' },
   { key: 'cost', label: 'Cost' },
 ];
-
-function alignDown(ts: number, range: HistoryRange): number {
-  const d = new Date(ts);
-  if (range === '1h') {
-    d.setMinutes(0, 0, 0);
-  } else if (range === '6h') {
-    d.setMinutes(0, 0, 0);
-    d.setHours(Math.floor(d.getHours() / 6) * 6);
-  } else {
-    d.setHours(0, 0, 0, 0);
-  }
-  return d.getTime();
-}
-
-/** Return [startOfMonthMs, endOfMonthMs] for the given month offset (0 = current). */
-function getMonthBoundaryMs(offset: number): [number, number] {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = now.getMonth(); // 0-11
-  // Go back `offset` months
-  let targetMonth = month - offset;
-  let targetYear = year;
-  while (targetMonth < 0) {
-    targetMonth += 12;
-    targetYear -= 1;
-  }
-  // Start of target month (local midnight of the 1st)
-  const start = new Date(targetYear, targetMonth, 1, 0, 0, 0, 0).getTime();
-  // End = start of next month
-  let nextMonth = targetMonth + 1;
-  let nextYear = targetYear;
-  if (nextMonth > 11) {
-    nextMonth = 0;
-    nextYear += 1;
-  }
-  const end = new Date(nextYear, nextMonth, 1, 0, 0, 0, 0).getTime();
-  return [start, end];
-}
 
 function isOffPeak(ts: number, start: string, end: string): boolean {
   const d = new Date(ts);
@@ -319,20 +283,6 @@ function getCharts(tab: MetricTab, importTariffCfg: TariffConfig, exportTariffCf
 // Helpers
 // ---------------------------------------------------------------------------
 
-function formatXAxis(ts: number, range: HistoryRange): string {
-  const d = new Date(ts);
-  if (range === '1h' || range === '6h' || range === '24h') {
-    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  }
-  if (range === '7d' || range === '30d') {
-    return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
-  }
-  if (range === 'month') {
-    return String(d.getDate());
-  }
-  return d.toLocaleDateString([], { month: 'short', year: 'numeric' });
-}
-
 function formatWindowLabel(range: HistoryRange, offset: number): string {
   if (range === 'month') {
     const now = new Date();
@@ -347,107 +297,36 @@ function formatWindowLabel(range: HistoryRange, offset: number): string {
     const d = new Date(targetYear, targetMonth, 1);
     return d.toLocaleDateString([], { month: 'long', year: 'numeric' });
   }
+  if (range === 'today') {
+    if (offset === 0) return 'Today';
+    const now = new Date();
+    const target = new Date(now.getFullYear(), now.getMonth(), now.getDate() - offset);
+    return target.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+  }
   if (offset === 0) return 'Now';
-  const rangeMs: Record<string, number> = {
-    '1h': 3600000,
-    '6h': 21600000,
-    '24h': 86400000,
-    '7d': 604800000,
-    '30d': 2592000000,
-    '6m': 15552000000,
-    '1y': 31536000000,
-  };
-  const ms = rangeMs[range] ?? 86400000;
+  const ms = HISTORY_RANGE_MS[range] ?? HISTORY_RANGE_MS['24h'] ?? 86400000;
   const end = new Date(Date.now() - offset * ms);
   const start = new Date(end.getTime() - ms);
-  const fmt = (d: Date) =>
-    range === '1h' || range === '6h' || range === '24h'
-      ? d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
-      : d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  const fmt = (d: Date) => {
+    if (range === '1h' || range === '6h' || range === '12h' || range === '24h') {
+      return d.toLocaleString([], {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    }
+    if (range === '6m' || range === '1y') {
+      return d.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+    }
+    return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  };
   return `${fmt(start)} — ${fmt(end)}`;
 }
 
 // ---------------------------------------------------------------------------
 // Single chart component
 // ---------------------------------------------------------------------------
-
-/** Generate clean evenly-spaced x-axis tick timestamps for any range.
- *
- * Returns `undefined` for ranges shorter than 7d (Recharts' auto-ticks
- * work well for intra-day views).
- */
-function getXAxisTicks(range: HistoryRange, domain: [number, number]): number[] | undefined {
-  const startMs = domain[0];
-  const endMs = domain[1];
-  const spanMs = endMs - startMs;
-  const startDate = new Date(startMs);
-
-  // --- Intra-day ranges: explicit hour/minute ticks ---
-  if (range === '1h') {
-    const ticks: number[] = [];
-    const cursor = new Date(startDate);
-    cursor.setMinutes(0, 0, 0); // align to minute 0
-    while (cursor.getTime() < endMs) {
-      ticks.push(cursor.getTime());
-      cursor.setMinutes(cursor.getMinutes() + 10); // every 10 min
-    }
-    return ticks;
-  }
-
-  if (range === '6h') {
-    const ticks: number[] = [];
-    const cursor = new Date(startDate);
-    cursor.setMinutes(0, 0, 0); // align to top of hour
-    while (cursor.getTime() < endMs) {
-      ticks.push(cursor.getTime());
-      cursor.setHours(cursor.getHours() + 1); // every 1 hour
-    }
-    return ticks;
-  }
-
-  if (range === '24h') {
-    const ticks: number[] = [];
-    const cursor = new Date(startDate);
-    cursor.setMinutes(0, 0, 0);
-    while (cursor.getTime() < endMs) {
-      ticks.push(cursor.getTime());
-      cursor.setHours(cursor.getHours() + 3); // every 3 hours
-    }
-    return ticks;
-  }
-
-  // --- 6m / 1y: month-level ticks ---
-  if (range === '6m' || range === '1y') {
-    const endDate = new Date(endMs);
-    const totalMonths = (endDate.getFullYear() - startDate.getFullYear()) * 12
-      + (endDate.getMonth() - startDate.getMonth());
-    const stepMonths = Math.max(1, Math.floor(totalMonths / 6));
-    const ticks: number[] = [];
-    for (let i = 0; i <= totalMonths; i += stepMonths) {
-      const m = startDate.getMonth() + i;
-      const y = startDate.getFullYear() + Math.floor(m / 12);
-      const t = new Date(y, m % 12, 1);
-      ticks.push(t.getTime());
-    }
-    return ticks;
-  }
-
-  // --- 7d / 30d / month: day-level ticks every ~5 days + last day ---
-  const totalDays = spanMs / 86400000;
-  const numDays = Math.round(totalDays);
-  const step = Math.max(1, Math.floor(numDays / 6));
-  const daysTicks: number[] = [];
-  for (let i = 0; i < numDays; i += step) {
-    const t = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate() + i);
-    daysTicks.push(t.getTime());
-  }
-  // Always include the last day
-  const lastDayTs = endMs - 86400000;
-  if (daysTicks.length === 0 || Math.abs(daysTicks[daysTicks.length - 1] - lastDayTs) > 3600000) {
-    daysTicks.push(lastDayTs);
-  }
-  return daysTicks;
-}
 
 function ChartCard({ chart, data, range, domain, ticks }: {
   chart: ChartDef;
@@ -528,18 +407,18 @@ function ChartCard({ chart, data, range, domain, ticks }: {
               </linearGradient>
             ))}
           </defs>
-          <CartesianGrid strokeDasharray="4 4" stroke="var(--color-grid-stroke)" strokeWidth={2} />
+          <CartesianGrid {...HISTORY_CHART_GRID_PROPS} />
           <XAxis
             dataKey="t"
             type="number"
             domain={domain}
             ticks={ticks}
-            tickFormatter={(v: number) => formatXAxis(v, range)}
+            tickFormatter={(v: number) => formatHistoryXAxisTick(v, range)}
             stroke="#8B949E"
             tick={{ fontSize: 11, style: { fontWeight: 700 } }}
             tickLine={false}
             axisLine={false}
-            minTickGap={range === '1h' || range === '6h' || range === '24h' ? 30 : 40}
+            minTickGap={getHistoryXAxisMinTickGap(range)}
           />
           <YAxis
             stroke="#8B949E"
@@ -721,43 +600,12 @@ export default function HistoryPage() {
   const [data, setData] = useState<Record<string, TimePoint[]>>({});
   
   const now = useNow();
-  const rangeMs: Record<string, number> = {
-    '1h': 3600000,
-    '6h': 21600000,
-    '24h': 86400000,
-    '7d': 604800000,
-    '30d': 2592000000,
-    '6m': 15552000000,
-    '1y': 31536000000,
-  };
-
-  // For calendar month view, use exact month boundaries as the domain.
-  // This ensures the x-axis always spans the full 1st to last day of the
-  // month regardless of data availability.
-  const monthBoundary = range === 'month' ? getMonthBoundaryMs(offset) : null;
-  const xDomain: [number, number] = range === 'month' && monthBoundary
-    ? monthBoundary
-    : (() => {
-        const windowMs = rangeMs[range] ?? 86400000;
-        const domainEnd = now - offset * windowMs;
-        const alignedEnd = alignDown(domainEnd, range) + windowMs;
-        return [alignedEnd - windowMs, alignedEnd];
-      })();
-
-  // Trim the domain start to the earliest data point so the line reaches
-  // the y-axis instead of leaving a gap. Only for 1h/6h (not 24h — the
-  // user expects 24h to always span midnight to midnight).
-  const effectiveDomain: [number, number] = (() => {
-    if (range !== '1h' && range !== '6h') return xDomain;
-    let firstTs = Infinity;
-    for (const pts of Object.values(data)) {
-      if (pts.length > 0 && pts[0].t < firstTs) firstTs = pts[0].t;
-    }
-    if (firstTs !== Infinity && firstTs > xDomain[0]) {
-      return [firstTs, xDomain[1]];
-    }
-    return xDomain;
-  })();
+  const rolling = isRollingHistoryRange(range);
+  const refreshKey = shouldRefreshHistoryRange(range, offset) ? now : 0;
+  const xDomain: [number, number] = getHistoryRangeDomain(range, offset, now);
+  const displayDomain = shouldTrimHistoryRangeLeadingGap(range)
+    ? trimDomainStartToFirstDataPoint(xDomain, data)
+    : xDomain;
 
   const [importTariffCfg, setImportTariffCfg] = useState<TariffConfig>({
     peak_rate: 0.285, off_peak_rate: 0.09, off_peak_start: '00:30', off_peak_end: '05:30',
@@ -795,7 +643,7 @@ export default function HistoryPage() {
         ...charts.flatMap((c) => c.requires ?? []),
       ]),
     ];
-    fetchHistory(range, allFields, offset)
+    fetchHistory(range, allFields, offset, rolling)
       .then((result) => {
         if (!cancelled) {
           const cleaned: Record<string, TimePoint[]> = {};
@@ -811,7 +659,7 @@ export default function HistoryPage() {
         }
       })
     return () => { cancelled = true; };
-  }, [tab, range, offset, importTariffCfg, exportTariffCfg]);
+  }, [tab, range, offset, importTariffCfg, exportTariffCfg, refreshKey, rolling]);
 
   const handleTabChange = (t: MetricTab) => {
     setTab(t);
@@ -855,7 +703,7 @@ export default function HistoryPage() {
 
       {/* Time range */}
       <div className="flex items-center gap-2 bg-bg-surface rounded-xl p-2 overflow-x-auto">
-        {RANGES.map((r) => (
+        {HISTORY_RANGES.map((r) => (
           <button
             key={r.key}
             onClick={() => handleRangeChange(r.key)}
@@ -927,8 +775,8 @@ export default function HistoryPage() {
               chart={chart}
               data={data}
               range={range}
-              domain={effectiveDomain}
-              ticks={getXAxisTicks(range, effectiveDomain)}
+              domain={displayDomain}
+              ticks={getHistoryXAxisTicks(range, displayDomain)}
             />
           ))}
         </div>

--- a/src/pages/PowerPage.tsx
+++ b/src/pages/PowerPage.tsx
@@ -33,12 +33,15 @@ type PowerSeriesKey =
   | 'gridPower'
   | 'homePower';
 
+type PowerChartKey = PowerSeriesKey | 'soc';
+
 interface PowerRow {
   t: number;
   solarPower: number | null;
   batteryPower: number | null;
   gridPower: number | null;
   homePower: number | null;
+  soc: number | null;
 }
 
 interface PowerHistoryState {
@@ -47,7 +50,7 @@ interface PowerHistoryState {
   error: string;
 }
 
-const HISTORY_FIELDS = ['solar_power', 'battery_power', 'grid_power', 'home_power'];
+const HISTORY_FIELDS = ['solar_power', 'battery_power', 'grid_power', 'home_power', 'soc'];
 const EMPTY_HISTORY_DATA: Record<string, TimePoint[]> = {};
 
 const POWER_SERIES: { key: PowerSeriesKey; label: string; color: string }[] = [
@@ -59,6 +62,7 @@ const POWER_SERIES: { key: PowerSeriesKey; label: string; color: string }[] = [
 
 const HOME_POWER_SERIES = POWER_SERIES.find((series) => series.key === 'homePower');
 const DIRECTIONAL_POWER_SERIES = POWER_SERIES.filter((series) => series.key !== 'homePower');
+const SOC_SERIES = { key: 'soc', label: 'Battery SOC', color: '#A78BFA' } as const;
 
 const SPIKE_THRESHOLD_W = 4000;
 
@@ -91,6 +95,7 @@ function buildPowerRows(data: Record<string, TimePoint[]>): PowerRow[] {
   const battery = pointsByTimestamp(data.battery_power);
   const grid = pointsByTimestamp(data.grid_power);
   const home = pointsByTimestamp(data.home_power);
+  const soc = pointsByTimestamp(data.soc);
   const timestamps = new Set<number>();
 
   for (const field of HISTORY_FIELDS) {
@@ -104,6 +109,7 @@ function buildPowerRows(data: Record<string, TimePoint[]>): PowerRow[] {
     const batteryValue = battery.get(t);
     const gridValue = grid.get(t);
     const homeValue = home.get(t);
+    const socValue = soc.get(t);
 
     return {
       t,
@@ -111,6 +117,7 @@ function buildPowerRows(data: Record<string, TimePoint[]>): PowerRow[] {
       batteryPower: batteryValue == null ? null : -batteryValue,
       gridPower: gridValue == null ? null : -gridValue,
       homePower: homeValue == null ? null : Math.max(homeValue, 0),
+      soc: socValue == null ? null : Math.min(100, Math.max(0, socValue)),
     };
   });
 }
@@ -131,6 +138,10 @@ function formatAxisWatts(value: number): string {
   const abs = Math.abs(value);
   if (abs >= 1000) return `${value < 0 ? '-' : ''}${Math.round(abs / 100) / 10}k`;
   return `${Math.round(value)}`;
+}
+
+function formatAxisPercent(value: number): string {
+  return `${Math.round(value)}%`;
 }
 
 function useNow(): number {
@@ -308,6 +319,13 @@ export default function PowerPage() {
                 <span className="text-text-secondary">{series.label}</span>
               </span>
             ))}
+            <span className="flex items-center gap-1.5 text-xs font-sans font-semibold">
+              <span
+                className="inline-block w-5 h-0.5 shrink-0"
+                style={{ backgroundColor: SOC_SERIES.color }}
+              />
+              <span className="text-text-secondary">{SOC_SERIES.label}</span>
+            </span>
           </div>
         </div>
 
@@ -329,7 +347,7 @@ export default function PowerPage() {
           </div>
         ) : (
           <ResponsiveContainer width="100%" height={320}>
-            <ComposedChart data={rows} margin={{ top: 10, right: 10, left: -12, bottom: 0 }}>
+            <ComposedChart data={rows} margin={{ top: 10, right: 4, left: -12, bottom: 0 }}>
               <defs>
                 {DIRECTIONAL_POWER_SERIES.map((series) => (
                   <linearGradient
@@ -346,7 +364,12 @@ export default function PowerPage() {
                 ))}
               </defs>
               <CartesianGrid {...HISTORY_CHART_GRID_PROPS} />
-              <ReferenceLine y={0} stroke="rgba(255,255,255,0.28)" strokeWidth={1.5} />
+              <ReferenceLine
+                yAxisId="power"
+                y={0}
+                stroke="rgba(255,255,255,0.28)"
+                strokeWidth={1.5}
+              />
               <XAxis
                 dataKey="t"
                 type="number"
@@ -360,12 +383,24 @@ export default function PowerPage() {
                 minTickGap={getHistoryXAxisMinTickGap(range)}
               />
               <YAxis
+                yAxisId="power"
                 stroke="#8B949E"
                 tick={{ fontSize: 11, style: { fontWeight: 700 } }}
                 tickLine={false}
                 axisLine={false}
                 domain={yDomain}
                 tickFormatter={(v: number) => formatAxisWatts(v)}
+              />
+              <YAxis
+                yAxisId="soc"
+                orientation="right"
+                width={36}
+                stroke={SOC_SERIES.color}
+                tick={{ fontSize: 11, style: { fontWeight: 700 }, fill: SOC_SERIES.color }}
+                tickLine={false}
+                axisLine={false}
+                domain={[0, 100]}
+                tickFormatter={(v: number) => formatAxisPercent(v)}
               />
               <Tooltip
                 contentStyle={{
@@ -381,7 +416,10 @@ export default function PowerPage() {
                 }}
                 formatter={(value, name) => {
                   const n = typeof value === 'number' ? value : Number(value);
-                  const key = String(name) as PowerSeriesKey;
+                  const key = String(name) as PowerChartKey;
+                  if (key === SOC_SERIES.key) {
+                    return [formatAxisPercent(n), SOC_SERIES.label];
+                  }
                   const label = POWER_SERIES.find((series) => series.key === key)?.label ?? name;
                   const batteryDirection = n < 0 ? 'Charge' : n > 0 ? 'Discharge' : '';
                   const gridDirection = n < 0 ? 'Export' : n > 0 ? 'Import' : '';
@@ -396,6 +434,7 @@ export default function PowerPage() {
               {DIRECTIONAL_POWER_SERIES.map((series) => (
                 <Area
                   key={series.key}
+                  yAxisId="power"
                   type="monotone"
                   dataKey={series.key}
                   stroke={series.color}
@@ -408,6 +447,7 @@ export default function PowerPage() {
               ))}
               {HOME_POWER_SERIES && (
                 <Line
+                  yAxisId="power"
                   type="monotone"
                   dataKey={HOME_POWER_SERIES.key}
                   stroke={HOME_POWER_SERIES.color}
@@ -418,6 +458,18 @@ export default function PowerPage() {
                   connectNulls
                 />
               )}
+              <Line
+                yAxisId="soc"
+                type="monotone"
+                dataKey={SOC_SERIES.key}
+                stroke={SOC_SERIES.color}
+                strokeWidth={2}
+                strokeDasharray="5 4"
+                dot={false}
+                activeDot={{ r: 4 }}
+                isAnimationActive={false}
+                connectNulls
+              />
             </ComposedChart>
           </ResponsiveContainer>
         )}

--- a/src/pages/PowerPage.tsx
+++ b/src/pages/PowerPage.tsx
@@ -1,0 +1,427 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { fetchHistory } from '../lib/api';
+import {
+  HISTORY_CHART_GRID_PROPS,
+  HISTORY_RANGES,
+  getHistoryRangeDomain,
+  getHistoryXAxisMinTickGap,
+  getHistoryXAxisTicks,
+  formatHistoryXAxisTick,
+  isRollingHistoryRange,
+  shouldRefreshHistoryRange,
+  shouldTrimHistoryRangeLeadingGap,
+  trimDomainStartToFirstDataPoint,
+} from '../lib/historyRangeConfig';
+import { formatPower } from '../lib/format';
+import type { HistoryRange, TimePoint } from '../lib/types';
+import { useInverterStore } from '../store/useInverterStore';
+
+type PowerSeriesKey =
+  | 'solarPower'
+  | 'batteryPower'
+  | 'gridPower'
+  | 'homePower';
+
+interface PowerRow {
+  t: number;
+  solarPower: number | null;
+  batteryPower: number | null;
+  gridPower: number | null;
+  homePower: number | null;
+}
+
+interface PowerHistoryState {
+  range: HistoryRange | null;
+  data: Record<string, TimePoint[]>;
+  error: string;
+}
+
+const HISTORY_FIELDS = ['solar_power', 'battery_power', 'grid_power', 'home_power'];
+const EMPTY_HISTORY_DATA: Record<string, TimePoint[]> = {};
+
+const POWER_SERIES: { key: PowerSeriesKey; label: string; color: string }[] = [
+  { key: 'solarPower', label: 'Combined PV', color: '#F59E0B' },
+  { key: 'batteryPower', label: 'Battery', color: '#22C55E' },
+  { key: 'gridPower', label: 'Grid', color: '#EF4444' },
+  { key: 'homePower', label: 'Load / Home', color: '#14B8A6' },
+];
+
+const HOME_POWER_SERIES = POWER_SERIES.find((series) => series.key === 'homePower');
+const DIRECTIONAL_POWER_SERIES = POWER_SERIES.filter((series) => series.key !== 'homePower');
+
+const SPIKE_THRESHOLD_W = 4000;
+
+function removePowerSpikes(points: TimePoint[]): TimePoint[] {
+  if (points.length < 3) return points;
+  return points.map((point, i) => {
+    if (i === 0 || i === points.length - 1) return point;
+    const prev = points[i - 1];
+    const next = points[i + 1];
+    const dPrev = Math.abs(point.v - prev.v);
+    const dNext = Math.abs(point.v - next.v);
+    const dNeighbors = Math.abs(next.v - prev.v);
+    if (
+      dPrev > SPIKE_THRESHOLD_W
+      && dNext > SPIKE_THRESHOLD_W
+      && dNeighbors < SPIKE_THRESHOLD_W * 0.5
+    ) {
+      return { t: point.t, v: (prev.v + next.v) / 2 };
+    }
+    return point;
+  });
+}
+
+function pointsByTimestamp(points: TimePoint[] | undefined): Map<number, number> {
+  return new Map((points ?? []).map((p) => [p.t, p.v]));
+}
+
+function buildPowerRows(data: Record<string, TimePoint[]>): PowerRow[] {
+  const solar = pointsByTimestamp(data.solar_power);
+  const battery = pointsByTimestamp(data.battery_power);
+  const grid = pointsByTimestamp(data.grid_power);
+  const home = pointsByTimestamp(data.home_power);
+  const timestamps = new Set<number>();
+
+  for (const field of HISTORY_FIELDS) {
+    for (const point of data[field] ?? []) {
+      timestamps.add(point.t);
+    }
+  }
+
+  return [...timestamps].sort((a, b) => a - b).map((t) => {
+    const solarValue = solar.get(t);
+    const batteryValue = battery.get(t);
+    const gridValue = grid.get(t);
+    const homeValue = home.get(t);
+
+    return {
+      t,
+      solarPower: solarValue == null ? null : Math.max(solarValue, 0),
+      batteryPower: batteryValue == null ? null : -batteryValue,
+      gridPower: gridValue == null ? null : -gridValue,
+      homePower: homeValue == null ? null : Math.max(homeValue, 0),
+    };
+  });
+}
+
+function calculateDomain(rows: PowerRow[]): [number, number] {
+  const max = rows.reduce((acc, row) => {
+    const rowMax = POWER_SERIES.reduce((seriesAcc, series) => {
+      const value = row[series.key];
+      return Math.max(seriesAcc, Math.abs(value ?? 0));
+    }, 0);
+    return Math.max(acc, rowMax);
+  }, 0);
+  const rounded = Math.max(1000, Math.ceil(max / 1000) * 1000);
+  return [-rounded, rounded];
+}
+
+function formatAxisWatts(value: number): string {
+  const abs = Math.abs(value);
+  if (abs >= 1000) return `${value < 0 ? '-' : ''}${Math.round(abs / 100) / 10}k`;
+  return `${Math.round(value)}`;
+}
+
+function useNow(): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60000);
+    return () => clearInterval(id);
+  }, []);
+  return now;
+}
+
+function PowerStat({ label, value, color, direction, waiting }: {
+  label: string;
+  value: number;
+  color: string;
+  direction: string;
+  waiting?: boolean;
+}) {
+  return (
+    <div className="bg-bg-elevated rounded-xl px-4 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-text-secondary text-xs font-sans">{label}</span>
+        <span className="text-[10px] uppercase tracking-wide font-semibold" style={{ color }}>
+          {direction}
+        </span>
+      </div>
+      <div className="mt-2 min-h-7 flex items-end">
+        {waiting ? (
+          <span className="text-text-secondary text-xs font-sans font-medium">
+            Waiting for data
+          </span>
+        ) : (
+          <span className="text-text-primary text-xl font-mono font-bold">
+            {formatPower(value)}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function PowerPage() {
+  const snapshot = useInverterStore((state) => state.snapshot);
+  const [range, setRange] = useState<HistoryRange>('24h');
+  const now = useNow();
+  const rolling = isRollingHistoryRange(range);
+  const refreshKey = shouldRefreshHistoryRange(range) ? now : 0;
+  const [history, setHistory] = useState<PowerHistoryState>({
+    range: null,
+    data: {},
+    error: '',
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchHistory(range, HISTORY_FIELDS, 0, rolling)
+      .then((result) => {
+        if (cancelled) return;
+        const cleaned: Record<string, TimePoint[]> = {};
+        for (const [field, points] of Object.entries(result)) {
+          cleaned[field] = removePowerSpikes(points);
+        }
+        setHistory({ range, data: cleaned, error: '' });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setHistory({
+          range,
+          data: {},
+          error: err instanceof Error ? err.message : 'Failed to load power history',
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [range, refreshKey, rolling]);
+
+  const loading = history.range !== range;
+  const data = loading ? EMPTY_HISTORY_DATA : history.data;
+  const error = loading ? '' : history.error;
+  const rows = useMemo(() => buildPowerRows(data), [data]);
+  const xDomain = useMemo(() => getHistoryRangeDomain(range, 0, now), [range, now]);
+  const displayDomain = useMemo(
+    () => shouldTrimHistoryRangeLeadingGap(range) ? trimDomainStartToFirstDataPoint(xDomain, data) : xDomain,
+    [data, range, xDomain],
+  );
+  const yDomain = useMemo(() => calculateDomain(rows), [rows]);
+  const hasData = rows.length > 0;
+  const waitingForLiveData = snapshot == null;
+
+  const currentSolar = Math.max(snapshot?.solar_power ?? 0, 0);
+  const currentBattery = snapshot?.battery_power ?? 0;
+  const currentGrid = snapshot?.grid_power ?? 0;
+  const currentHome = Math.max(snapshot?.home_power ?? 0, 0);
+  const batteryDirection = currentBattery < 0 ? 'Discharging' : currentBattery > 0 ? 'Charging' : 'Idle';
+  const batteryColor = currentBattery < 0 ? '#22C55E' : currentBattery > 0 ? '#6366F1' : '#8B949E';
+  const gridDirection = currentGrid < 0 ? 'Importing' : currentGrid > 0 ? 'Exporting' : 'Idle';
+  const gridColor = currentGrid < 0 ? '#EF4444' : currentGrid > 0 ? '#38BDF8' : '#8B949E';
+
+  return (
+    <div className="flex flex-col gap-4 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-text-primary text-lg font-semibold font-sans">Power</h1>
+          <p className="text-text-secondary text-xs font-sans">
+            Live and historical power direction
+          </p>
+        </div>
+        <div className="text-text-secondary text-xs font-sans text-right">
+          {snapshot ? new Date(snapshot.timestamp).toLocaleTimeString() : 'Waiting for data'}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <PowerStat
+          label="Combined PV"
+          value={currentSolar}
+          color="#F59E0B"
+          direction="Generation"
+          waiting={waitingForLiveData}
+        />
+        <PowerStat
+          label="Battery"
+          value={Math.abs(currentBattery)}
+          color={batteryColor}
+          direction={batteryDirection}
+          waiting={waitingForLiveData}
+        />
+        <PowerStat
+          label="Grid"
+          value={Math.abs(currentGrid)}
+          color={gridColor}
+          direction={gridDirection}
+          waiting={waitingForLiveData}
+        />
+        <PowerStat
+          label="Load / Home"
+          value={currentHome}
+          color="#14B8A6"
+          direction="Load"
+          waiting={waitingForLiveData}
+        />
+      </div>
+
+      <div className="flex items-center gap-2 bg-bg-surface rounded-xl p-2 overflow-x-auto">
+        {HISTORY_RANGES.map((r) => (
+          <button
+            key={r.key}
+            type="button"
+            onClick={() => setRange(r.key)}
+            className={`shrink-0 px-3 py-1.5 rounded-lg text-xs font-sans font-medium transition-colors ${
+              range === r.key
+                ? 'bg-flow-active text-bg-base'
+                : 'bg-bg-elevated text-text-secondary hover:text-text-primary'
+            }`}
+          >
+            {r.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="bg-bg-elevated rounded-xl p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-3">
+          <h2 className="text-text-primary text-sm font-sans font-bold">Power Flow</h2>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+            {POWER_SERIES.map((series) => (
+              <span
+                key={series.key}
+                className="flex items-center gap-1.5 text-xs font-sans font-semibold"
+              >
+                <span
+                  className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+                  style={{ backgroundColor: series.color }}
+                />
+                <span className="text-text-secondary">{series.label}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="flex flex-col items-center justify-center h-[320px] gap-4">
+            <div className="w-8 h-8 border-4 border-flow-active border-t-transparent rounded-full animate-spin" />
+            <p className="text-text-secondary text-sm font-sans">Loading power history…</p>
+          </div>
+        ) : error ? (
+          <div className="flex items-center justify-center h-[320px] text-red-400 text-sm font-sans">
+            {error}
+          </div>
+        ) : !hasData ? (
+          <div className="flex flex-col items-center justify-center h-[320px] gap-2">
+            <p className="text-text-secondary text-sm font-sans">No power history for this range</p>
+            <p className="text-text-secondary/50 text-xs font-sans">
+              History is recorded while the app is running and connected
+            </p>
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={320}>
+            <ComposedChart data={rows} margin={{ top: 10, right: 10, left: -12, bottom: 0 }}>
+              <defs>
+                {DIRECTIONAL_POWER_SERIES.map((series) => (
+                  <linearGradient
+                    key={series.key}
+                    id={`power-grad-${series.key}`}
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
+                    <stop offset="5%" stopColor={series.color} stopOpacity={0.28} />
+                    <stop offset="95%" stopColor={series.color} stopOpacity={0} />
+                  </linearGradient>
+                ))}
+              </defs>
+              <CartesianGrid {...HISTORY_CHART_GRID_PROPS} />
+              <ReferenceLine y={0} stroke="rgba(255,255,255,0.28)" strokeWidth={1.5} />
+              <XAxis
+                dataKey="t"
+                type="number"
+                domain={displayDomain}
+                ticks={getHistoryXAxisTicks(range, displayDomain)}
+                tickFormatter={(v: number) => formatHistoryXAxisTick(v, range)}
+                stroke="#8B949E"
+                tick={{ fontSize: 11, style: { fontWeight: 700 } }}
+                tickLine={false}
+                axisLine={false}
+                minTickGap={getHistoryXAxisMinTickGap(range)}
+              />
+              <YAxis
+                stroke="#8B949E"
+                tick={{ fontSize: 11, style: { fontWeight: 700 } }}
+                tickLine={false}
+                axisLine={false}
+                domain={yDomain}
+                tickFormatter={(v: number) => formatAxisWatts(v)}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: '#21262D',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  borderRadius: '8px',
+                  fontSize: '12px',
+                  color: '#F0F6FC',
+                }}
+                labelFormatter={(v) => {
+                  const n = typeof v === 'number' ? v : Number(v);
+                  return new Date(n).toLocaleString();
+                }}
+                formatter={(value, name) => {
+                  const n = typeof value === 'number' ? value : Number(value);
+                  const key = String(name) as PowerSeriesKey;
+                  const label = POWER_SERIES.find((series) => series.key === key)?.label ?? name;
+                  const batteryDirection = n < 0 ? 'Charge' : n > 0 ? 'Discharge' : '';
+                  const gridDirection = n < 0 ? 'Export' : n > 0 ? 'Import' : '';
+                  const displayLabel = key === 'batteryPower' && batteryDirection
+                    ? 'Battery ' + batteryDirection
+                    : key === 'gridPower' && gridDirection
+                      ? 'Grid ' + gridDirection
+                      : label;
+                  return [formatPower(Math.abs(n)), displayLabel];
+                }}
+              />
+              {DIRECTIONAL_POWER_SERIES.map((series) => (
+                <Area
+                  key={series.key}
+                  type="monotone"
+                  dataKey={series.key}
+                  stroke={series.color}
+                  fill={`url(#power-grad-${series.key})`}
+                  strokeWidth={2}
+                  dot={false}
+                  isAnimationActive={false}
+                  connectNulls
+                />
+              ))}
+              {HOME_POWER_SERIES && (
+                <Line
+                  type="monotone"
+                  dataKey={HOME_POWER_SERIES.key}
+                  stroke={HOME_POWER_SERIES.color}
+                  strokeWidth={3}
+                  dot={false}
+                  activeDot={{ r: 4 }}
+                  isAnimationActive={false}
+                  connectNulls
+                />
+              )}
+            </ComposedChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a new Power page with live power tiles and historical power flow charts, including battery SOC on a secondary percentage axis.

Also includes a few minor supporting fixes:
- share time range configuration between Power and History pages
- add `12h` and `Today` history filters
- make numeric filters use rolling windows
- keep `Today` and `Month` as calendar windows
- align chart axis/grid styling across Power and History

I hope you don't mind my making a submission out of the blue. Happy to create a related issue, add docs updates, or make any adjustments to suit.

## Screenshot:
<img width="1358" height="871" alt="image" src="https://github.com/user-attachments/assets/37a8d22b-1004-4a6f-990a-401a39fe165c" />


## Checks

- npm run lint
- npm run build
- docker compose build givenergy-local
- docker compose up -d --force-recreate givenergy-local
- smoke-tested `/api/status`
- smoke-tested `/api/history?range=12h&fields=soc&rolling=true`
- smoke-tested `/api/history?range=24h&fields=solar_power,battery_power,grid_power,home_power,soc&rolling=true`
