### PR TITLE
Make chart legends interactive and share chart range selection

### DIFF
--- a/e2e/charts.spec.ts
+++ b/e2e/charts.spec.ts
@@ -1,0 +1,78 @@
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from './fixture.js';
+
+async function waitForHistoryData(baseUrl: string): Promise<void> {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const params = new URLSearchParams({
+      range: '24h',
+      fields: 'battery_power,today_charge_kwh,today_discharge_kwh',
+      rolling: 'true',
+    });
+    const resp = await fetch(`${baseUrl}/api/history?${params}`);
+    const body = await resp.json();
+    const data = body.data as Record<string, { t: number; v: number }[]> | undefined;
+    if (data && Object.values(data).some((points) => points.length > 0)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error('Timed out waiting for history data');
+}
+
+async function expectRangeSelected(page: Page, label: string) {
+  await expect(page.getByRole('button', { name: label })).toHaveAttribute('aria-pressed', 'true');
+}
+
+async function expectLegendToggle(button: Locator) {
+  await expect(button).toHaveAttribute('aria-pressed', 'true');
+  const muteTitle = await button.getAttribute('title');
+  expect(muteTitle).toMatch(/^Mute /);
+
+  await button.click();
+  await expect(button).toHaveAttribute('aria-pressed', 'false');
+  const showTitle = await button.getAttribute('title');
+  expect(showTitle).toBe(muteTitle?.replace('Mute ', 'Show '));
+
+  await button.click();
+  await expect(button).toHaveAttribute('aria-pressed', 'true');
+  await expect(button).toHaveAttribute('title', muteTitle ?? '');
+}
+
+test.describe('Chart ranges', () => {
+  test('selected time range is shared between Power and History pages', async ({ page }) => {
+    await page.goto('/#/power');
+    await expect(page.getByRole('heading', { name: 'Power Flow' })).toBeVisible();
+
+    await page.getByRole('button', { name: '6h' }).click();
+    await expectRangeSelected(page, '6h');
+
+    await page.getByRole('link', { name: 'History' }).click();
+    await expectRangeSelected(page, '6h');
+
+    await page.getByRole('button', { name: '12h' }).click();
+    await expectRangeSelected(page, '12h');
+
+    await page.getByRole('link', { name: 'Power' }).click();
+    await expect(page.getByRole('heading', { name: 'Power Flow' })).toBeVisible();
+    await expectRangeSelected(page, '12h');
+  });
+});
+
+test.describe('Chart legends', () => {
+  test('Power page legend items can be muted and restored', async ({ page }) => {
+    await page.goto('/#/power');
+    await expect(page.getByRole('heading', { name: 'Power Flow' })).toBeVisible();
+
+    await expectLegendToggle(page.getByRole('button', { name: 'Battery SOC' }));
+  });
+
+  test('History page multi-series legends can be muted and restored', async ({ page, baseUrl }) => {
+    await waitForHistoryData(baseUrl);
+
+    await page.goto('/#/history');
+    await expect(page.getByRole('heading', { name: 'Charge / Discharge Power' })).toBeVisible();
+
+    await expectLegendToggle(page.getByRole('button', { name: 'Charge' }).first());
+  });
+});

--- a/e2e/charts.spec.ts
+++ b/e2e/charts.spec.ts
@@ -47,15 +47,29 @@ test.describe('Chart ranges', () => {
     await page.getByRole('button', { name: '6h' }).click();
     await expectRangeSelected(page, '6h');
 
-    await page.getByRole('link', { name: 'History' }).click();
+    await page.goto('/#/history');
     await expectRangeSelected(page, '6h');
 
     await page.getByRole('button', { name: '12h' }).click();
     await expectRangeSelected(page, '12h');
 
-    await page.getByRole('link', { name: 'Power' }).click();
+    await page.goto('/#/power');
     await expect(page.getByRole('heading', { name: 'Power Flow' })).toBeVisible();
     await expectRangeSelected(page, '12h');
+  });
+
+  test('selected time range survives a page reload', async ({ page }) => {
+    await page.goto('/#/power');
+    await page.evaluate(() => localStorage.removeItem('chartRange'));
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Power Flow' })).toBeVisible();
+
+    await page.getByRole('button', { name: '6h' }).click();
+    await expectRangeSelected(page, '6h');
+
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Power Flow' })).toBeVisible();
+    await expectRangeSelected(page, '6h');
   });
 });
 

--- a/src/components/SeriesLegend.tsx
+++ b/src/components/SeriesLegend.tsx
@@ -1,0 +1,43 @@
+export interface SeriesLegendItem<Key extends string = string> {
+  key: Key;
+  label: string;
+  color: string;
+  marker?: 'dot' | 'line';
+}
+
+export function SeriesLegend<Key extends string>({
+  items,
+  muted,
+  onToggle,
+}: {
+  items: readonly SeriesLegendItem<Key>[];
+  muted: Partial<Record<Key, boolean>>;
+  onToggle: (key: Key) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-2">
+      {items.map((series) => {
+        const isMuted = muted[series.key] ?? false;
+        const isLine = series.marker === 'line';
+        return (
+          <button
+            key={series.key}
+            type="button"
+            aria-pressed={!isMuted}
+            title={isMuted ? `Show ${series.label}` : `Mute ${series.label}`}
+            onClick={() => onToggle(series.key)}
+            className={`flex items-center gap-1.5 rounded-md px-1.5 py-1 text-xs font-sans font-semibold transition-opacity hover:opacity-100 ${
+              isMuted ? 'opacity-40' : 'opacity-100'
+            }`}
+          >
+            <span
+              className={`inline-block shrink-0 ${isLine ? 'w-5 h-0.5' : 'w-2.5 h-2.5 rounded-full'}`}
+              style={{ backgroundColor: series.color }}
+            />
+            <span className="text-text-secondary">{series.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/chartSeries.ts
+++ b/src/lib/chartSeries.ts
@@ -1,0 +1,3 @@
+export function getSeriesOpacity(muted: boolean): number {
+  return muted ? 0.22 : 1;
+}

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -22,6 +22,10 @@ import {
   shouldTrimHistoryRangeLeadingGap,
   trimDomainStartToFirstDataPoint,
 } from '../lib/historyRangeConfig';
+import { getSeriesOpacity } from '../lib/chartSeries';
+import { SeriesLegend } from '../components/SeriesLegend';
+import { useInverterStore } from '../store/useInverterStore';
+import type { SeriesLegendItem } from '../components/SeriesLegend';
 import type { HistoryRange, PollSettings, TariffConfig } from '../lib/types';
 
 // ---------------------------------------------------------------------------
@@ -335,6 +339,7 @@ function ChartCard({ chart, data, range, domain, ticks }: {
   domain: [number, number];
   ticks?: number[];
 }) {
+  const [mutedSeries, setMutedSeries] = useState<Partial<Record<string, boolean>>>({});
   const allFields = [...chart.fields.map((f) => f.field), ...(chart.requires ?? [])];
   const uniqueFields = [...new Set(allFields)];
 
@@ -367,6 +372,14 @@ function ChartCard({ chart, data, range, domain, ticks }: {
     const suffix = chart.fields.filter((ff, j) => j < i && ff.field === f.field).length;
     return `${f.field}${suffix > 0 ? `_${suffix}` : ''}`;
   });
+  const legendItems: SeriesLegendItem[] = chart.fields.map((f, i) => ({
+    key: seriesNames[i],
+    label: f.label ?? f.field,
+    color: f.color,
+  }));
+  const toggleSeries = (key: string) => {
+    setMutedSeries((current) => ({ ...current, [key]: !current[key] }));
+  };
 
   const seriesData = merged.map((row) => {
     const out: Record<string, number | null> = { t: row.t };
@@ -384,17 +397,7 @@ function ChartCard({ chart, data, range, domain, ticks }: {
       <div className="flex items-center justify-between mb-3 gap-2">
         <h3 className="text-text-primary text-sm font-sans font-bold">{chart.title}</h3>
         {chart.fields.length > 1 && (
-          <div className="flex items-center gap-3">
-            {chart.fields.map((f, i) => (
-              <span key={i} className="flex items-center gap-1.5 text-xs font-sans font-semibold">
-                <span
-                  className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
-                  style={{ backgroundColor: f.color }}
-                />
-                <span className="text-text-secondary">{f.label ?? f.field}</span>
-              </span>
-            ))}
-          </div>
+          <SeriesLegend items={legendItems} muted={mutedSeries} onToggle={toggleSeries} />
         )}
       </div>
       <ResponsiveContainer width="100%" height={200}>
@@ -456,6 +459,7 @@ function ChartCard({ chart, data, range, domain, ticks }: {
               dataKey={seriesNames[i]}
               stroke={f.color}
               fill={`url(#grad-${chart.key}-${i})`}
+              opacity={getSeriesOpacity(mutedSeries[seriesNames[i]] ?? false)}
               strokeWidth={2}
               dot={false}
               isAnimationActive={false}
@@ -595,7 +599,8 @@ function useNow(): number {
 
 export default function HistoryPage() {
   const [tab, setTab] = useState<MetricTab>('battery');
-  const [range, setRange] = useState<HistoryRange>('24h');
+  const range = useInverterStore((state) => state.chartRange);
+  const setChartRange = useInverterStore((state) => state.setChartRange);
   const [offset, setOffset] = useState(0);
   const [data, setData] = useState<Record<string, TimePoint[]>>({});
   
@@ -667,7 +672,7 @@ export default function HistoryPage() {
   };
 
   const handleRangeChange = (r: HistoryRange) => {
-    setRange(r);
+    setChartRange(r);
     setOffset(0);
   };
 
@@ -706,6 +711,8 @@ export default function HistoryPage() {
         {HISTORY_RANGES.map((r) => (
           <button
             key={r.key}
+            type="button"
+            aria-pressed={range === r.key}
             onClick={() => handleRangeChange(r.key)}
             className={`shrink-0 px-3 py-1.5 rounded-lg text-xs font-sans font-medium transition-colors ${
               range === r.key

--- a/src/pages/PowerPage.tsx
+++ b/src/pages/PowerPage.tsx
@@ -11,6 +11,7 @@ import {
   YAxis,
 } from 'recharts';
 import { fetchHistory } from '../lib/api';
+import { SeriesLegend } from '../components/SeriesLegend';
 import {
   HISTORY_CHART_GRID_PROPS,
   HISTORY_RANGES,
@@ -24,6 +25,8 @@ import {
   trimDomainStartToFirstDataPoint,
 } from '../lib/historyRangeConfig';
 import { formatPower } from '../lib/format';
+import { getSeriesOpacity } from '../lib/chartSeries';
+import type { SeriesLegendItem } from '../components/SeriesLegend';
 import type { HistoryRange, TimePoint } from '../lib/types';
 import { useInverterStore } from '../store/useInverterStore';
 
@@ -63,6 +66,10 @@ const POWER_SERIES: { key: PowerSeriesKey; label: string; color: string }[] = [
 const HOME_POWER_SERIES = POWER_SERIES.find((series) => series.key === 'homePower');
 const DIRECTIONAL_POWER_SERIES = POWER_SERIES.filter((series) => series.key !== 'homePower');
 const SOC_SERIES = { key: 'soc', label: 'Battery SOC', color: '#A78BFA' } as const;
+const POWER_CHART_SERIES: SeriesLegendItem<PowerChartKey>[] = [
+  ...POWER_SERIES,
+  { ...SOC_SERIES, marker: 'line' },
+];
 
 const SPIKE_THRESHOLD_W = 4000;
 
@@ -185,7 +192,8 @@ function PowerStat({ label, value, color, direction, waiting }: {
 
 export default function PowerPage() {
   const snapshot = useInverterStore((state) => state.snapshot);
-  const [range, setRange] = useState<HistoryRange>('24h');
+  const range = useInverterStore((state) => state.chartRange);
+  const setRange = useInverterStore((state) => state.setChartRange);
   const now = useNow();
   const rolling = isRollingHistoryRange(range);
   const refreshKey = shouldRefreshHistoryRange(range) ? now : 0;
@@ -194,6 +202,7 @@ export default function PowerPage() {
     data: {},
     error: '',
   });
+  const [mutedSeries, setMutedSeries] = useState<Partial<Record<PowerChartKey, boolean>>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -231,6 +240,9 @@ export default function PowerPage() {
   const yDomain = useMemo(() => calculateDomain(rows), [rows]);
   const hasData = rows.length > 0;
   const waitingForLiveData = snapshot == null;
+  const toggleSeries = (key: PowerChartKey) => {
+    setMutedSeries((current) => ({ ...current, [key]: !current[key] }));
+  };
 
   const currentSolar = Math.max(snapshot?.solar_power ?? 0, 0);
   const currentBattery = snapshot?.battery_power ?? 0;
@@ -291,6 +303,7 @@ export default function PowerPage() {
           <button
             key={r.key}
             type="button"
+            aria-pressed={range === r.key}
             onClick={() => setRange(r.key)}
             className={`shrink-0 px-3 py-1.5 rounded-lg text-xs font-sans font-medium transition-colors ${
               range === r.key
@@ -306,27 +319,7 @@ export default function PowerPage() {
       <div className="bg-bg-elevated rounded-xl p-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-3">
           <h2 className="text-text-primary text-sm font-sans font-bold">Power Flow</h2>
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-            {POWER_SERIES.map((series) => (
-              <span
-                key={series.key}
-                className="flex items-center gap-1.5 text-xs font-sans font-semibold"
-              >
-                <span
-                  className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
-                  style={{ backgroundColor: series.color }}
-                />
-                <span className="text-text-secondary">{series.label}</span>
-              </span>
-            ))}
-            <span className="flex items-center gap-1.5 text-xs font-sans font-semibold">
-              <span
-                className="inline-block w-5 h-0.5 shrink-0"
-                style={{ backgroundColor: SOC_SERIES.color }}
-              />
-              <span className="text-text-secondary">{SOC_SERIES.label}</span>
-            </span>
-          </div>
+          <SeriesLegend items={POWER_CHART_SERIES} muted={mutedSeries} onToggle={toggleSeries} />
         </div>
 
         {loading ? (
@@ -439,6 +432,7 @@ export default function PowerPage() {
                   dataKey={series.key}
                   stroke={series.color}
                   fill={`url(#power-grad-${series.key})`}
+                  opacity={getSeriesOpacity(mutedSeries[series.key] ?? false)}
                   strokeWidth={2}
                   dot={false}
                   isAnimationActive={false}
@@ -451,9 +445,10 @@ export default function PowerPage() {
                   type="monotone"
                   dataKey={HOME_POWER_SERIES.key}
                   stroke={HOME_POWER_SERIES.color}
+                  opacity={getSeriesOpacity(mutedSeries[HOME_POWER_SERIES.key] ?? false)}
                   strokeWidth={3}
                   dot={false}
-                  activeDot={{ r: 4 }}
+                  activeDot={mutedSeries[HOME_POWER_SERIES.key] ? false : { r: 4 }}
                   isAnimationActive={false}
                   connectNulls
                 />
@@ -463,10 +458,11 @@ export default function PowerPage() {
                 type="monotone"
                 dataKey={SOC_SERIES.key}
                 stroke={SOC_SERIES.color}
+                opacity={getSeriesOpacity(mutedSeries[SOC_SERIES.key] ?? false)}
                 strokeWidth={2}
                 strokeDasharray="5 4"
                 dot={false}
-                activeDot={{ r: 4 }}
+                activeDot={mutedSeries[SOC_SERIES.key] ? false : { r: 4 }}
                 isAnimationActive={false}
                 connectNulls
               />

--- a/src/store/useInverterStore.ts
+++ b/src/store/useInverterStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { InverterSnapshot, ConnectionState, ScheduleSlot } from '../lib/types';
+import type { InverterSnapshot, ConnectionState, HistoryRange, ScheduleSlot } from '../lib/types';
 
 type ThemeMode = 'dark' | 'light';
 
@@ -9,6 +9,8 @@ interface InverterState {
   connectedHost: string | null;
   developerMode: boolean;
   themeMode: ThemeMode;
+  /** Shared time range used by Power and History charts. */
+  chartRange: HistoryRange;
   /** Discharge slots configured locally in Eco mode, not yet written to the inverter. */
   pendingDischargeSlots: Record<number, ScheduleSlot>;
   setSnapshot: (snapshot: InverterSnapshot) => void;
@@ -16,6 +18,7 @@ interface InverterState {
   setConnection: (state: ConnectionState, host?: string) => void;
   setDeveloperMode: (enabled: boolean) => void;
   setThemeMode: (mode: ThemeMode) => void;
+  setChartRange: (range: HistoryRange) => void;
   setPendingDischargeSlots: (slots: Record<number, ScheduleSlot>) => void;
   clearPendingDischargeSlots: () => void;
 }
@@ -34,6 +37,29 @@ function loadThemeMode(): ThemeMode {
     return stored === 'light' ? 'light' : 'dark';
   } catch {
     return 'dark';
+  }
+}
+
+function loadChartRange(): HistoryRange {
+  try {
+    const stored = localStorage.getItem('chartRange');
+    switch (stored) {
+      case '1h':
+      case '6h':
+      case '12h':
+      case '24h':
+      case 'today':
+      case '7d':
+      case '30d':
+      case 'month':
+      case '6m':
+      case '1y':
+        return stored;
+      default:
+        return '24h';
+    }
+  } catch {
+    return '24h';
   }
 }
 
@@ -57,6 +83,7 @@ export const useInverterStore = create<InverterState>((set) => ({
   connectedHost: null,
   developerMode: loadDeveloperMode(),
   themeMode: loadThemeMode(),
+  chartRange: loadChartRange(),
   pendingDischargeSlots: loadPendingDischargeSlots(),
   setSnapshot: (snapshot) => set({ snapshot }),
   clearSnapshot: () => set({ snapshot: null }),
@@ -72,6 +99,12 @@ export const useInverterStore = create<InverterState>((set) => ({
       localStorage.setItem('themeMode', mode);
     } catch { /* ignore */ }
     set({ themeMode: mode });
+  },
+  setChartRange: (range) => {
+    try {
+      localStorage.setItem('chartRange', range);
+    } catch { /* ignore */ }
+    set({ chartRange: range });
   },
   setPendingDischargeSlots: (slots) => {
     savePendingDischargeSlots(slots);


### PR DESCRIPTION
## Summary

This draft PR proposes a couple of small chart usability improvements:

- Add a shared SeriesLegend component with selectable legend items
- Allow Power chart series and multi-series History charts to be muted/restored
- Share the selected chart time range between Power and History pages
- Persist the shared range selection in local storage
- Add Playwright coverage for range sync and legend toggles

I hope you don't mind my making another submission, admittedly this is more of a polishing! I remembered to get my AI guy to update the tests this time - hopefully!

## Screenshot:

<img width="1358" height="741" alt="image" src="https://github.com/user-attachments/assets/a4dfc961-c026-4d2b-a2e6-b24e5eaddd1a" />

## Verification

- `npm run lint`
- `npm run lint:md`
- `npm run build`
- `cargo clippy`
- `cargo test` - 261 passed
- `npm run test:e2e` - 28 passed
- `docker build .`

These were run using containerized equivalents locally because the host environment does not have local npm/cargo/Chrome available.
