### PR TITLE
Fix History page charts displaying 1 hour behind local time

### DIFF
--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -650,29 +650,10 @@ export default function HistoryPage() {
       .then((result) => {
         if (!cancelled) {
           const cleaned: Record<string, TimePoint[]> = {};
-          // Convert UTC timestamps from the backend to local time so the
-          // chart's X-axis (which uses local-time domain boundaries) aligns
-          // correctly. The inverter's today_*_kwh counters reset at UTC
-          // midnight; without this shift the reset appears 1 hour late in
-          // timezones east of UTC (e.g. 01:00 in BST).
-          //
-          // `getTimezoneOffset()` returns minutes to *add* to local time to
-          // get UTC (negative for zones east of UTC), so adding it to a UTC
-          // timestamp gives the equivalent local-time epoch ms.
-          //
-          // The shift also pushes points from 00:00–01:00 local back into
-          // the previous local day (they still carry yesterday's counter
-          // values). Trim those — they're outside the Today window and would
-          // otherwise extend the X-axis to start before midnight.
-          const tzOffsetMs = new Date().getTimezoneOffset() * 60 * 1000;
-          const domainStartMs = xDomain[0];
+          // Timestamps are UTC epoch ms; new Date(t) and the local-time axis
+          // helpers localize them at render, so plot them unchanged.
           for (const [field, pts] of Object.entries(result)) {
-            cleaned[field] = removeSpikes(
-              pts
-                .map((p) => ({ t: p.t + tzOffsetMs, v: p.v }))
-                .filter((p) => p.t >= domainStartMs),
-              field,
-            );
+            cleaned[field] = removeSpikes(pts, field);
           }
           setData(cleaned);
         }
@@ -683,7 +664,7 @@ export default function HistoryPage() {
         }
       })
     return () => { cancelled = true; };
-  }, [tab, range, offset, importTariffCfg, exportTariffCfg, refreshKey, rolling, xDomain]);
+  }, [tab, range, offset, importTariffCfg, exportTariffCfg, refreshKey, rolling]);
 
   const handleTabChange = (t: MetricTab) => {
     setTab(t);


### PR DESCRIPTION
## What

The History page (every tab) plotted all series ~1 hour behind local time in timezones east of UTC (e.g. BST). The standalone Battery / Solar / Power pages were unaffected.

## Cause

c7b7acd added `getTimezoneOffset()` to every fetched point's UTC-epoch timestamp in `HistoryPage`, to reposition the `today_*_kwh` midnight-reset step from its true 01:00 BST spot to 00:00. That shifted the **entire x-axis** (every series, every tab) back by the offset.

Backend `.t` values are already UTC epoch ms; `new Date(t)` and the local-time axis helpers (`getHistoryRangeDomain` / `formatHistoryXAxisTick`) localize them at render. The Battery / Solar / Power charts plot the raw `.t` and read correctly.

## Fix

Drop the timestamp shift (and the now-unused `xDomain` effect dependency) so `HistoryPage` plots the raw UTC timestamps like the other charts.

The backend repair change from c7b7acd (`repair_cumulative_points` using `same_utc_day`) is correct and left intact. Note: with the display shift gone, the daily-counter reset step on the Energy / Cost charts again sits at its true ~01:00 BST time (the counters are UTC-based) rather than being cosmetically pulled to 00:00.

## Verified

On a live v0.39.2 instance (BST, `getTimezoneOffset = -60`): `/api/history` latest SOC point reads 16:40 local, 4 minutes behind real time, so the data and timezone are both correct. Before this fix the History page rendered that point at 15:40; the standalone Battery / Solar / Power pages rendered it at ~16:40.

## Possible follow-up (not in this PR)

The timestamp-keyed series merge is currently reimplemented in four places (`PowerPage.buildPowerRows`, `SolarPowerChart`, `HistoryPage`, with `BatterySocChart` on the single-series path), each free to mishandle `.t` independently. A good follow-up would consolidate them into one shared, pure `assembleChartRows(result, fields, { despike })` helper that preserves timestamps, then unit-test it (plus `historyRangeConfig`) under a fixed non-UTC timezone. That turns four independent time paths into one tested path and guards the whole chart subsystem against this class of bug, rather than just this page.
