### PR TITLE
Directional power charts no longer collapse to ~0 at coarse zoom

### DIFF
--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -134,6 +134,52 @@ pub fn is_cost_field(field: &str) -> bool {
     field == IMPORT_COST_FIELD || field == EXPORT_INCOME_FIELD
 }
 
+/// Field names for the server-derived DIRECTIONAL power series.
+///
+/// The stored `battery_power` and `grid_power` columns are SIGNED (negative =
+/// charge / grid-import, positive = discharge / grid-export). Splitting them by
+/// sign on the client AFTER the server has `AVG`-aggregated each bucket lets the
+/// two directions cancel inside a wide bucket, collapsing the directional charts
+/// toward 0 at coarse zoom (a full day of charging and discharging nets to ~0,
+/// so the 24h-bucket 1-year view flat-lines). These derived fields instead
+/// average each direction's magnitude independently per bucket - the signed
+/// split happens INSIDE the `AVG`, before aggregation - so the directions never
+/// cancel. Mirrors the derive-then-downsample pattern already used for
+/// `_import_cost` / `_export_income`.
+pub const CHARGE_POWER_FIELD: &str = "_charge_power";
+pub const DISCHARGE_POWER_FIELD: &str = "_discharge_power";
+pub const GRID_IMPORT_POWER_FIELD: &str = "_grid_import_power";
+pub const GRID_EXPORT_POWER_FIELD: &str = "_grid_export_power";
+
+/// Map a directional field to `(source_column, signed-magnitude SQL)`.
+///
+/// The magnitude expression is averaged per bucket; the source column drives the
+/// `IS NOT NULL` row guard (the `CASE` itself is never NULL). Both halves are
+/// compile-time string literals over a fixed column, so the formatted SQL
+/// carries no untrusted input - this is what lets directional fields safely
+/// bypass the `is_allowed_field` column whitelist in `query_history`.
+fn directional_sql(field: &str) -> Option<(&'static str, &'static str)> {
+    match field {
+        CHARGE_POWER_FIELD => Some((
+            "battery_power",
+            "CASE WHEN battery_power < 0 THEN -battery_power ELSE 0 END",
+        )),
+        DISCHARGE_POWER_FIELD => Some((
+            "battery_power",
+            "CASE WHEN battery_power > 0 THEN battery_power ELSE 0 END",
+        )),
+        GRID_IMPORT_POWER_FIELD => Some((
+            "grid_power",
+            "CASE WHEN grid_power < 0 THEN -grid_power ELSE 0 END",
+        )),
+        GRID_EXPORT_POWER_FIELD => Some((
+            "grid_power",
+            "CASE WHEN grid_power > 0 THEN grid_power ELSE 0 END",
+        )),
+        _ => None,
+    }
+}
+
 /// Coarse upper bound (kW) used only to reject a grossly corrupted counter
 /// value that slipped past ingestion. A per-reading delta is discarded only if
 /// it would require sustaining more than this over the actual elapsed time
@@ -968,42 +1014,58 @@ impl HistoryDb {
         let mut result = serde_json::Map::new();
 
         for field in fields {
-            if !is_allowed_field(field) {
-                continue;
-            }
+            // Directional power fields (`_charge_power`, `_grid_import_power`, …)
+            // are derived: they average a SIGNED-SPLIT magnitude of an existing
+            // column so charge/discharge (or import/export) don't cancel within a
+            // bucket. They bypass the plain `is_allowed_field` column whitelist
+            // via `directional_sql`, which only maps a fixed set of names to
+            // constant SQL over a known column. Everything downstream (bucketing,
+            // TimePoint shape) is identical to a plain aggregated field.
+            let (table, value_expr, null_guard) =
+                if let Some((source_col, magnitude_expr)) = directional_sql(field) {
+                    (
+                        "readings",
+                        format!("AVG({magnitude_expr})"),
+                        format!("\"{source_col}\""),
+                    )
+                } else {
+                    if !is_allowed_field(field) {
+                        continue;
+                    }
 
-            let agg = if is_cumulative_field(field) {
-                "MAX"
-            } else {
-                "AVG"
-            };
+                    let agg = if is_cumulative_field(field) {
+                        "MAX"
+                    } else {
+                        "AVG"
+                    };
 
-            let table = if is_weather_field(field) {
-                "weather_observations"
-            } else {
-                "readings"
-            };
-            // Weather observations store temperature in `temperature_c` rather
-            // than the requested field name, so the SELECT has to alias the
-            // column. Every other field shares its name with the column.
-            let select_col = if is_weather_field(field) {
-                "temperature_c".to_string()
-            } else {
-                format!("\"{field}\"")
-            };
+                    let table = if is_weather_field(field) {
+                        "weather_observations"
+                    } else {
+                        "readings"
+                    };
+                    // Weather observations store temperature in `temperature_c`
+                    // rather than the requested field name, so the SELECT has to
+                    // alias the column. Every other field shares its name with
+                    // the column.
+                    let select_col = if is_weather_field(field) {
+                        "temperature_c".to_string()
+                    } else {
+                        format!("\"{field}\"")
+                    };
+
+                    (table, format!("{agg}({select_col})"), select_col)
+                };
 
             let sql = format!(
                 "SELECT \
                     ((timestamp / {bucket}) * {bucket}) * 1000 AS t_bucket, \
-                    {agg}({select_col}) AS v \
+                    {value_expr} AS v \
                  FROM {table} \
-                 WHERE timestamp >= ?1 AND timestamp < ?2 AND {select_col} IS NOT NULL \
+                 WHERE timestamp >= ?1 AND timestamp < ?2 AND {null_guard} IS NOT NULL \
                  GROUP BY t_bucket \
                  ORDER BY t_bucket",
                 bucket = bucket_secs,
-                agg = agg,
-                table = table,
-                select_col = select_col,
             );
 
             let mut stmt = conn
@@ -1510,6 +1572,96 @@ mod tests {
         let db = test_db();
         let result = db
             .query_history(600, 60, 0, &["DROP TABLE readings".to_string()], None)
+            .unwrap();
+        assert!(result.is_empty());
+    }
+
+    /// Regression for the directional sign-cancellation bug: within a single
+    /// bucket that contains both charging and discharging, the net
+    /// `AVG(battery_power)`
+    /// cancels toward 0 - which is exactly what the old client-side sign split
+    /// saw, collapsing both directional series. The derived `_charge_power` /
+    /// `_discharge_power` (and grid import/export) fields must instead report
+    /// each direction's true average magnitude, because the split happens
+    /// inside the aggregate.
+    #[test]
+    fn directional_fields_do_not_cancel_within_a_bucket() {
+        let db = test_db();
+        let base = 1_700_000_000i64;
+
+        // Four readings inside one bucket. Battery nets to exactly 0
+        // (-2000, +2000, -1000, +1000) yet charges in two and discharges in
+        // two. Grid imports (-3000, -1000) and exports (+2000, +500) in the
+        // same bucket. (Sign convention: battery/grid negative = charge/import.)
+        let samples = [
+            (base, -2000i32, -3000i32),
+            (base + 60, 2000, 2000),
+            (base + 120, -1000, -1000),
+            (base + 180, 1000, 500),
+        ];
+        for (ts, battery_power, grid_power) in samples {
+            db.insert_reading(&InverterSnapshot {
+                timestamp: ts,
+                battery_power,
+                grid_power,
+                ..Default::default()
+            });
+        }
+
+        // One 24h bucket so all four readings aggregate together - the coarse
+        // bucket case where the broken client split flat-lined.
+        let result = db
+            .query_history(
+                100_000_000,
+                86_400,
+                0,
+                &[
+                    "battery_power".to_string(),
+                    CHARGE_POWER_FIELD.to_string(),
+                    DISCHARGE_POWER_FIELD.to_string(),
+                    GRID_IMPORT_POWER_FIELD.to_string(),
+                    GRID_EXPORT_POWER_FIELD.to_string(),
+                ],
+                None,
+            )
+            .unwrap();
+
+        let single = |field: &str| -> f64 {
+            let pts: Vec<TimePoint> =
+                serde_json::from_value(result.get(field).cloned().unwrap()).unwrap();
+            assert_eq!(pts.len(), 1, "expected one bucket for {field}, got {}", pts.len());
+            pts[0].v
+        };
+
+        // Net average cancels to ~0 - the symptom the directional fields fix.
+        assert!(
+            single("battery_power").abs() < 1.0,
+            "net battery_power should cancel to ~0, got {}",
+            single("battery_power"),
+        );
+
+        // charge magnitudes 2000,0,1000,0 -> avg 750; discharge 0,2000,0,1000 -> 750.
+        assert!((single(CHARGE_POWER_FIELD) - 750.0).abs() < 0.01);
+        assert!((single(DISCHARGE_POWER_FIELD) - 750.0).abs() < 0.01);
+        // import magnitudes 3000,0,1000,0 -> avg 1000; export 0,2000,0,500 -> 625.
+        assert!((single(GRID_IMPORT_POWER_FIELD) - 1000.0).abs() < 0.01);
+        assert!((single(GRID_EXPORT_POWER_FIELD) - 625.0).abs() < 0.01);
+    }
+
+    /// Directional fields bypass the column whitelist via an exact name->SQL
+    /// map, so a lookalike / injection-shaped field name must still be rejected
+    /// with no SQL built.
+    #[test]
+    fn rejects_directional_lookalike_field() {
+        let db = test_db();
+        let result = db
+            .query_history(
+                600,
+                60,
+                0,
+                &["_charge_power; DROP TABLE readings".to_string()],
+                None,
+            )
             .unwrap();
         assert!(result.is_empty());
     }

--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -158,26 +158,40 @@ pub const GRID_EXPORT_POWER_FIELD: &str = "_grid_export_power";
 /// compile-time string literals over a fixed column, so the formatted SQL
 /// carries no untrusted input - this is what lets directional fields safely
 /// bypass the `is_allowed_field` column whitelist in `query_history`.
+///
+/// Each `CASE WHEN` wraps its source column in `COALESCE(…, 0)` so the
+/// magnitude stays 0 instead of NULL when a row's column is NULL. Today
+/// `battery_power` / `grid_power` are non-NULL in the schema (poll.rs
+/// defaults them to 0 when the dongle omits them), but the coalesce
+/// keeps the directional series robust if that ever changes.
 fn directional_sql(field: &str) -> Option<(&'static str, &'static str)> {
     match field {
         CHARGE_POWER_FIELD => Some((
             "battery_power",
-            "CASE WHEN battery_power < 0 THEN -battery_power ELSE 0 END",
+            "CASE WHEN COALESCE(battery_power, 0) < 0 THEN -COALESCE(battery_power, 0) ELSE 0 END",
         )),
         DISCHARGE_POWER_FIELD => Some((
             "battery_power",
-            "CASE WHEN battery_power > 0 THEN battery_power ELSE 0 END",
+            "CASE WHEN COALESCE(battery_power, 0) > 0 THEN COALESCE(battery_power, 0) ELSE 0 END",
         )),
         GRID_IMPORT_POWER_FIELD => Some((
             "grid_power",
-            "CASE WHEN grid_power < 0 THEN -grid_power ELSE 0 END",
+            "CASE WHEN COALESCE(grid_power, 0) < 0 THEN -COALESCE(grid_power, 0) ELSE 0 END",
         )),
         GRID_EXPORT_POWER_FIELD => Some((
             "grid_power",
-            "CASE WHEN grid_power > 0 THEN grid_power ELSE 0 END",
+            "CASE WHEN COALESCE(grid_power, 0) > 0 THEN COALESCE(grid_power, 0) ELSE 0 END",
         )),
         _ => None,
     }
+}
+
+/// True for the server-derived directional power fields. Mirrors
+/// [`is_cost_field`] so callers outside `history/` (e.g. the API layer
+/// or tests) can ask "is this a derived field?" without re-encoding the
+/// field-name list.
+pub fn is_directional_field(field: &str) -> bool {
+    directional_sql(field).is_some()
 }
 
 /// Coarse upper bound (kW) used only to reject a grossly corrupted counter
@@ -986,11 +1000,25 @@ impl HistoryDb {
     /// - `bucket_secs`: aggregation bucket size in seconds (e.g. 300 for 5m)
     /// - `offset`: number of windows to go back (0 = most recent). Ignored
     ///   when `explicit_window` is provided.
-    /// - `fields`: comma-separated list of field names
+    /// - `fields`: list of field names. Each is one of:
+    ///   - a column on `readings` (or `weather_observations` for
+    ///     `external_temperature`) - validated by [`is_allowed_field`]
+    ///     against the SQL-injection whitelist;
+    ///   - `_import_cost` / `_export_income` - the cost/income series are
+    ///     routed out to `query_cost_series` by the HTTP layer
+    ///     (`server/api.rs`), NOT computed here;
+    ///   - `_charge_power` / `_discharge_power` / `_grid_import_power` /
+    ///     `_grid_export_power` - server-derived directional series that
+    ///     `AVG(CASE WHEN …)` a signed magnitude per bucket so charge
+    ///     never cancels discharge (or import cancels export) inside a
+    ///     wide bucket (PR #166). Routed via [`directional_sql`].
     /// - `explicit_window`: optional (start_ts, end_ts) in UTC epoch seconds.
     ///   When provided, `range_secs` and `offset` are ignored entirely.
     ///
-    /// Returns a map from field name to Vec<TimePoint>.
+    /// Returns a map from field name to Vec<TimePoint>. Unrecognised
+    /// field names are silently skipped (no SQL is built for them), so a
+    /// request that mixes known and unknown fields still succeeds for
+    /// the known ones.
     pub fn query_history(
         &self,
         range_secs: i64,
@@ -1664,6 +1692,171 @@ mod tests {
             )
             .unwrap();
         assert!(result.is_empty());
+    }
+
+    /// One bad field name must not poison the whole query: the unknown
+    /// field is silently skipped, while every known field still returns
+    /// its data. The HTTP layer relies on this to keep custom tabs working
+    /// after the directional fields (or any future derived field) are
+    /// added to the request list.
+    #[test]
+    fn unknown_field_does_not_shadow_known_fields() {
+        let db = test_db();
+        // Use the standard 'window covers everything' range from the
+        // other history tests so the single inserted reading is always
+        // inside the query window regardless of wall-clock time.
+        let base = 1_700_000_000i64;
+        db.insert_reading(&InverterSnapshot {
+            timestamp: base,
+            battery_power: -1500,
+            grid_power: 800,
+            ..Default::default()
+        });
+        let result = db
+            .query_history(
+                100_000_000,
+                60,
+                0,
+                &[
+                    CHARGE_POWER_FIELD.to_string(),
+                    "_not_a_real_field".to_string(),
+                    "solar_power".to_string(),
+                    GRID_EXPORT_POWER_FIELD.to_string(),
+                ],
+                None,
+            )
+            .unwrap();
+        // Known fields returned non-empty…
+        assert!(result.get(CHARGE_POWER_FIELD).is_some());
+        assert!(result.get(GRID_EXPORT_POWER_FIELD).is_some());
+        assert!(result.get("solar_power").is_some());
+        // …and the unknown one did not appear.
+        assert!(result.get("_not_a_real_field").is_none());
+        // Spot-check a value: that one reading was pure charge and pure
+        // export, so the directional avg equals the reading itself.
+        let charge_pts: Vec<TimePoint> = serde_json::from_value(
+            result.get(CHARGE_POWER_FIELD).cloned().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(charge_pts.len(), 1);
+        assert!((charge_pts[0].v - 1500.0).abs() < 0.01);
+    }
+
+    /// A bucket with exclusively charging readings must report full
+    /// magnitude on the charge series and exactly 0 on the discharge
+    /// series. Symmetrically, a pure-discharge bucket must report 0 on
+    /// the charge series. The cancellation test alone does not exercise
+    /// the polarity branches - both `> 0` and `< 0` need at least one
+    /// direct hit each so an off-by-one sign flip in the SQL `CASE WHEN`
+    /// would be caught.
+    #[test]
+    fn directional_polarity_branches_are_correct() {
+        let db = test_db();
+        // Use a small bucket (60s) so each cluster reliably lands in its
+        // own bucket rather than getting aggregated together.
+        let bucket_secs = 60i64;
+        let t0 = 1_700_100_000i64; // arbitrary non-overlapping base
+
+        // Bucket A: three pure-charge readings (-400, -1000, -600 W),
+        // all inside the bucket starting at t0.
+        for (i, watts) in [-400i32, -1000, -600].iter().enumerate() {
+            db.insert_reading(&InverterSnapshot {
+                timestamp: t0 + (i as i64) * 10, // 0s, 10s, 20s
+                battery_power: *watts,
+                ..Default::default()
+            });
+        }
+        // Bucket B: three pure-discharge readings (300, 700, 500 W) in a
+        // separate bucket starting at t0 + 120s (well past the 60s bucket
+        // boundary, so they aggregate on their own).
+        for (i, watts) in [300i32, 700, 500].iter().enumerate() {
+            db.insert_reading(&InverterSnapshot {
+                timestamp: t0 + 120 + (i as i64) * 10, // 120s, 130s, 140s
+                battery_power: *watts,
+                ..Default::default()
+            });
+        }
+
+        let result = db
+            .query_history(
+                100_000_000,
+                bucket_secs,
+                0,
+                &[
+                    CHARGE_POWER_FIELD.to_string(),
+                    DISCHARGE_POWER_FIELD.to_string(),
+                ],
+                None,
+            )
+            .unwrap();
+
+        let pts = |f: &str| -> Vec<TimePoint> {
+            serde_json::from_value(result.get(f).cloned().unwrap()).unwrap()
+        };
+
+        let charge_pts = pts(CHARGE_POWER_FIELD);
+        let discharge_pts = pts(DISCHARGE_POWER_FIELD);
+        assert_eq!(charge_pts.len(), 2, "expected two charge buckets, got {charge_pts:?}");
+        assert_eq!(discharge_pts.len(), 2, "expected two discharge buckets, got {discharge_pts:?}");
+
+        // Bucket A: mean charge = (400+1000+600)/3 = 666.67; discharge = 0.
+        let bucket_a_start = (t0 / bucket_secs) * bucket_secs * 1000;
+        let bucket_b_start = ((t0 + 120) / bucket_secs) * bucket_secs * 1000;
+
+        let charge_a = charge_pts
+            .iter()
+            .find(|p| p.t == bucket_a_start)
+            .expect("bucket A on charge series");
+        assert!(
+            (charge_a.v - 666.666666667).abs() < 0.5,
+            "pure-charge bucket A should be ~666.67, got {}",
+            charge_a.v
+        );
+        let discharge_a = discharge_pts
+            .iter()
+            .find(|p| p.t == bucket_a_start)
+            .expect("bucket A on discharge series");
+        assert!(
+            discharge_a.v.abs() < 0.01,
+            "pure-charge bucket A on discharge series should be 0, got {}",
+            discharge_a.v
+        );
+
+        // Symmetric: pure-discharge bucket B.
+        let charge_b = charge_pts
+            .iter()
+            .find(|p| p.t == bucket_b_start)
+            .expect("bucket B on charge series");
+        assert!(
+            charge_b.v.abs() < 0.01,
+            "pure-discharge bucket B on charge series should be 0, got {}",
+            charge_b.v
+        );
+        let discharge_b = discharge_pts
+            .iter()
+            .find(|p| p.t == bucket_b_start)
+            .expect("bucket B on discharge series");
+        assert!(
+            (discharge_b.v - 500.0).abs() < 0.5,
+            "pure-discharge bucket B should be 500, got {}",
+            discharge_b.v
+        );
+    }
+
+    /// `is_directional_field` recognises all four directional names and
+    /// rejects everything else - mirrors the symmetry of `is_cost_field`
+    /// so contributors adding future derived fields have a clear pattern
+    /// to follow.
+    #[test]
+    fn is_directional_field_helper() {
+        assert!(is_directional_field(CHARGE_POWER_FIELD));
+        assert!(is_directional_field(DISCHARGE_POWER_FIELD));
+        assert!(is_directional_field(GRID_IMPORT_POWER_FIELD));
+        assert!(is_directional_field(GRID_EXPORT_POWER_FIELD));
+        assert!(!is_directional_field("battery_power"));
+        assert!(!is_directional_field("_import_cost"));
+        assert!(!is_directional_field("_charge_power; DROP TABLE readings"));
+        assert!(!is_directional_field(""));
     }
 
     #[test]

--- a/src/lib/chartSeries.ts
+++ b/src/lib/chartSeries.ts
@@ -17,6 +17,13 @@ export const SPIKE_THRESHOLDS: Record<string, number> = {
   battery_power: 4000,
   grid_power: 4000,
   home_power: 4000,
+  // Server-derived directional power magnitudes (split from battery_power /
+  // grid_power before bucket aggregation). Same scale as their source field,
+  // so the same 4000 W threshold applies.
+  _charge_power: 4000,
+  _discharge_power: 4000,
+  _grid_import_power: 4000,
+  _grid_export_power: 4000,
   // Daily energy counters (kWh) — these are cumulative monotonic counters
   // used to derive cost via delta computation. Even a small corruption of
   // 3-5 kWh produces a ~£1 cost spike at standard tariff rates.

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -50,7 +50,7 @@ type MetricTab = 'battery' | 'solar' | 'grid' | 'home' | 'cost' | 'temperature';
 interface ChartDef {
   key: string;
   title: string;
-  fields: { field: string; color: string; label?: string; transform?: (v: number) => number }[];
+  fields: { field: string; color: string; label?: string }[];
   unit: string;
   yDomain?: [number, number];
   /**
@@ -98,9 +98,14 @@ function getCharts(tab: MetricTab): ChartDef[] {
           key: 'battery-power',
           title: 'Charge / Discharge Power',
           unit: 'W',
+          // Server-derived directional fields: each direction's magnitude is
+          // averaged independently per bucket, so charge and discharge don't
+          // cancel inside a wide (12h/24h) bucket. Splitting a single signed
+          // `battery_power` by sign on the client AFTER the server averaged it
+          // collapsed both series toward 0 at coarse zoom.
           fields: [
-            { field: 'battery_power', color: '#22C55E', label: 'Charge', transform: (v: number) => v < 0 ? Math.abs(v) : 0 },
-            { field: 'battery_power', color: '#EF4444', label: 'Discharge', transform: (v: number) => v > 0 ? v : 0 },
+            { field: '_charge_power', color: '#22C55E', label: 'Charge' },
+            { field: '_discharge_power', color: '#EF4444', label: 'Discharge' },
           ],
         },
         {
@@ -141,9 +146,12 @@ function getCharts(tab: MetricTab): ChartDef[] {
           key: 'grid-power',
           title: 'Grid Power (W)',
           unit: 'W',
+          // Server-derived directional fields (see Charge/Discharge above):
+          // import and export are each averaged independently per bucket so a
+          // day that both imports and exports no longer collapses to its net.
           fields: [
-            { field: 'grid_power', color: '#22C55E', label: 'Export', transform: (v: number) => v > 0 ? v : 0 },
-            { field: 'grid_power', color: '#EF4444', label: 'Import', transform: (v: number) => v < 0 ? Math.abs(v) : 0 },
+            { field: '_grid_export_power', color: '#22C55E', label: 'Export' },
+            { field: '_grid_import_power', color: '#EF4444', label: 'Import' },
           ],
         },
         {
@@ -323,9 +331,7 @@ function ChartCard({ chart, data, range, domain, ticks, gridLineWeight }: {
     const out: Record<string, number | null> = { t: row.t };
     chart.fields.forEach((f, i) => {
       const name = seriesNames[i];
-      const raw = row[f.field];
-      const value = raw !== undefined && f.transform ? f.transform(raw) : (raw ?? null);
-      out[name] = value ?? null;
+      out[name] = row[f.field] ?? null;
     });
     return out;
   });

--- a/src/pages/PowerPage.tsx
+++ b/src/pages/PowerPage.tsx
@@ -35,6 +35,14 @@ import { SeriesLegend } from '../components/SeriesLegend';
 import type { SeriesLegendItem } from '../components/SeriesLegend';
 import type { HistoryRange, TimePoint } from '../lib/types';
 import { useInverterStore } from '../store/useInverterStore';
+import {
+  bucketSocAvg,
+  calculatePowerReport,
+  type PowerRow,
+  type PowerBucket,
+  type PowerReport,
+  type PowerReportSummary,
+} from './powerReport';
 
 type PowerSeriesKey =
   | 'solarPower'
@@ -43,24 +51,6 @@ type PowerSeriesKey =
   | 'homePower';
 
 type PowerChartKey = PowerSeriesKey | 'soc';
-
-interface PowerRow {
-  t: number;
-  solarPower: number | null;
-  batteryPower: number | null;
-  gridPower: number | null;
-  homePower: number | null;
-  soc: number | null;
-  // Directional magnitudes (W, >= 0), pre-split server-side before bucket
-  // aggregation. The Consumption Report integrates / peaks these instead of
-  // re-splitting the net battery/grid power, which cancels charge against
-  // discharge (import against export) within a wide bucket. Null when a
-  // timestamp has no sample.
-  chargePower: number | null;
-  dischargePower: number | null;
-  gridImportPower: number | null;
-  gridExportPower: number | null;
-}
 
 interface PowerHistoryState {
   range: HistoryRange | null;
@@ -79,58 +69,6 @@ const HISTORY_FIELDS = [
   '_charge_power', '_discharge_power', '_grid_import_power', '_grid_export_power',
 ];
 const EMPTY_HISTORY_DATA: Record<string, TimePoint[]> = {};
-
-interface PowerBucket {
-  start: number;
-  label: string;
-  solarKwh: number;
-  homeKwh: number;
-  importKwh: number;
-  exportKwh: number;
-  batteryChargeKwh: number;
-  batteryDischargeKwh: number;
-  socMin: number | null;
-  socMax: number | null;
-  socSum: number;
-  socCount: number;
-}
-
-interface PowerReportSummary {
-  periodLabel: string;
-  generatedAt: Date;
-  solarKwh: number;
-  homeKwh: number;
-  importKwh: number;
-  exportKwh: number;
-  netGridKwh: number;
-  batteryChargeKwh: number;
-  batteryDischargeKwh: number;
-  peakSolarW: number;
-  peakHomeW: number;
-  peakGridImportW: number;
-  peakGridExportW: number;
-  peakBatteryChargeW: number;
-  peakBatteryDischargeW: number;
-  socMin: number | null;
-  socMax: number | null;
-  socAvg: number | null;
-  solarCoveragePct: number | null;
-  gridDependencyPct: number | null;
-  // Issue #131: cost totals matching the selected range/offset. Sourced
-  // from /api/report (server-integrated from the today_*_kwh counters and
-  // the configured tariff). All values are GBP.
-  importCostGbp: number;
-  exportIncomeGbp: number;
-  netCostGbp: number;
-  standingChargeGbp: number;
-  standingChargePPerDay: number;
-  daysInRange: number;
-}
-
-interface PowerReport {
-  summary: PowerReportSummary;
-  buckets: PowerBucket[];
-}
 
 const POWER_SERIES: { key: PowerSeriesKey; label: string; color: string }[] = [
   { key: 'solarPower', label: 'Combined PV', color: '#F59E0B' },
@@ -378,203 +316,6 @@ function batteryDirection(value: number | null): string {
 function gridDirection(value: number | null): string {
   if (value == null || Math.abs(value) < 1) return 'Idle';
   return value > 0 ? 'Importing' : 'Exporting';
-}
-
-function medianIntervalMs(rows: PowerRow[]): number | null {
-  const intervals = rows
-    .slice(1)
-    .map((row, i) => row.t - rows[i].t)
-    .filter((dt) => dt > 0)
-    .sort((a, b) => a - b);
-  if (intervals.length === 0) return null;
-  return intervals[Math.floor(intervals.length / 2)];
-}
-
-function positivePart(value: number | null | undefined): number {
-  return Math.max(value ?? 0, 0);
-}
-
-function integratePair(
-  a: number | null,
-  b: number | null,
-  hours: number,
-  transform: (value: number | null | undefined) => number,
-): number {
-  if (a == null && b == null) return 0;
-  if (a == null) return transform(b) * hours / 1000;
-  if (b == null) return transform(a) * hours / 1000;
-  return ((transform(a) + transform(b)) / 2) * hours / 1000;
-}
-
-function bucketGranularity(range: HistoryRange): 'hour' | 'day' | 'month' {
-  if (range === '6m' || range === '1y') return 'month';
-  if (range === '7d' || range === '30d' || range === 'month') return 'day';
-  return 'hour';
-}
-
-function bucketStartMs(ts: number, range: HistoryRange): number {
-  const d = new Date(ts);
-  switch (bucketGranularity(range)) {
-    case 'month':
-      return new Date(d.getFullYear(), d.getMonth(), 1).getTime();
-    case 'day':
-      return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-    case 'hour':
-      return new Date(d.getFullYear(), d.getMonth(), d.getDate(), d.getHours()).getTime();
-  }
-}
-
-function bucketLabel(start: number, range: HistoryRange): string {
-  const d = new Date(start);
-  switch (bucketGranularity(range)) {
-    case 'month':
-      return d.toLocaleDateString([], { month: 'short', year: 'numeric' });
-    case 'day':
-      if (range === 'month') return String(d.getDate());
-      return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
-    case 'hour':
-      return d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit' });
-  }
-}
-
-function emptyBucket(start: number, range: HistoryRange): PowerBucket {
-  return {
-    start,
-    label: bucketLabel(start, range),
-    solarKwh: 0,
-    homeKwh: 0,
-    importKwh: 0,
-    exportKwh: 0,
-    batteryChargeKwh: 0,
-    batteryDischargeKwh: 0,
-    socMin: null,
-    socMax: null,
-    socSum: 0,
-    socCount: 0,
-  };
-}
-
-function addSoc(bucket: PowerBucket, soc: number | null) {
-  if (soc == null) return;
-  bucket.socMin = bucket.socMin == null ? soc : Math.min(bucket.socMin, soc);
-  bucket.socMax = bucket.socMax == null ? soc : Math.max(bucket.socMax, soc);
-  bucket.socSum += soc;
-  bucket.socCount += 1;
-}
-
-function bucketSocAvg(bucket: PowerBucket): number | null {
-  return bucket.socCount > 0 ? bucket.socSum / bucket.socCount : null;
-}
-
-function calculatePowerReport(rows: PowerRow[], range: HistoryRange, domain: [number, number], offset: number): PowerReport {
-  const buckets = new Map<number, PowerBucket>();
-  const getBucket = (ts: number) => {
-    const start = bucketStartMs(ts, range);
-    const existing = buckets.get(start);
-    if (existing) return existing;
-    const created = emptyBucket(start, range);
-    buckets.set(start, created);
-    return created;
-  };
-
-  const sortedRows = rows.filter((row) => row.t >= domain[0] && row.t <= domain[1]).sort((a, b) => a.t - b.t);
-  const medianMs = medianIntervalMs(sortedRows);
-  const maxGapMs = medianMs == null ? Infinity : medianMs * 3.5;
-
-  let solarKwh = 0;
-  let homeKwh = 0;
-  let importKwh = 0;
-  let exportKwh = 0;
-  let batteryChargeKwh = 0;
-  let batteryDischargeKwh = 0;
-
-  for (let i = 0; i < sortedRows.length - 1; i++) {
-    const a = sortedRows[i];
-    const b = sortedRows[i + 1];
-    const rawDt = b.t - a.t;
-    if (rawDt <= 0 || rawDt > maxGapMs) continue;
-    const start = Math.max(a.t, domain[0]);
-    const end = Math.min(b.t, domain[1]);
-    const hours = (end - start) / 3600000;
-    if (hours <= 0) continue;
-
-    const solar = integratePair(a.solarPower, b.solarPower, hours, positivePart);
-    const home = integratePair(a.homePower, b.homePower, hours, positivePart);
-    // Directional energy integrates the server-split magnitudes (already >= 0),
-    // not the net grid/battery power. Integrating the net would let a bucket's
-    // import and export (charge and discharge) cancel before integration - the
-    // same sign-cancellation the History directional charts had.
-    const gridImport = integratePair(a.gridImportPower, b.gridImportPower, hours, positivePart);
-    const gridExport = integratePair(a.gridExportPower, b.gridExportPower, hours, positivePart);
-    const batteryCharge = integratePair(a.chargePower, b.chargePower, hours, positivePart);
-    const batteryDischarge = integratePair(a.dischargePower, b.dischargePower, hours, positivePart);
-
-    solarKwh += solar;
-    homeKwh += home;
-    importKwh += gridImport;
-    exportKwh += gridExport;
-    batteryChargeKwh += batteryCharge;
-    batteryDischargeKwh += batteryDischarge;
-
-    const midpoint = start + (end - start) / 2;
-    const bucket = getBucket(midpoint);
-    bucket.solarKwh += solar;
-    bucket.homeKwh += home;
-    bucket.importKwh += gridImport;
-    bucket.exportKwh += gridExport;
-    bucket.batteryChargeKwh += batteryCharge;
-    bucket.batteryDischargeKwh += batteryDischarge;
-  }
-
-  for (const row of sortedRows) {
-    addSoc(getBucket(row.t), row.soc);
-  }
-
-  const socValues = sortedRows.map((row) => row.soc).filter((soc): soc is number => soc != null);
-  const socMin = socValues.length ? Math.min(...socValues) : null;
-  const socMax = socValues.length ? Math.max(...socValues) : null;
-  const socAvg = socValues.length ? socValues.reduce((acc, soc) => acc + soc, 0) / socValues.length : null;
-
-  const summary: PowerReportSummary = {
-    periodLabel: powerWindowLabel(range, offset),
-    generatedAt: new Date(),
-    solarKwh,
-    homeKwh,
-    importKwh,
-    exportKwh,
-    netGridKwh: importKwh - exportKwh,
-    batteryChargeKwh,
-    batteryDischargeKwh,
-    peakSolarW: Math.max(0, ...sortedRows.map((row) => positivePart(row.solarPower))),
-    peakHomeW: Math.max(0, ...sortedRows.map((row) => positivePart(row.homePower))),
-    // Peaks come from the directional magnitudes too (no net cancellation).
-    // These remain a max of per-bucket AVERAGES, so they understate the true
-    // instantaneous peak at coarse buckets - same as peakSolarW / peakHomeW.
-    peakGridImportW: Math.max(0, ...sortedRows.map((row) => positivePart(row.gridImportPower))),
-    peakGridExportW: Math.max(0, ...sortedRows.map((row) => positivePart(row.gridExportPower))),
-    peakBatteryChargeW: Math.max(0, ...sortedRows.map((row) => positivePart(row.chargePower))),
-    peakBatteryDischargeW: Math.max(0, ...sortedRows.map((row) => positivePart(row.dischargePower))),
-    socMin,
-    socMax,
-    socAvg,
-    solarCoveragePct: homeKwh > 0 ? solarKwh / homeKwh * 100 : null,
-    gridDependencyPct: homeKwh > 0 ? importKwh / homeKwh * 100 : null,
-    // Issue #131: cost totals sourced from /api/report (server-side
-    // integration against the configured tariff + standing charge). When
-    // the fetch hasn't returned yet, these stay at 0 and the report tiles
-    // show "—" via the formatGbp fallback in the export rendering.
-    importCostGbp: 0,
-    exportIncomeGbp: 0,
-    netCostGbp: 0,
-    standingChargeGbp: 0,
-    standingChargePPerDay: 0,
-    daysInRange: 0,
-  };
-
-  return {
-    summary,
-    buckets: [...buckets.values()].sort((a, b) => a.start - b.start),
-  };
 }
 
 function exportPowerCSV(report: PowerReport, rows: PowerRow[]) {
@@ -1094,7 +835,12 @@ export default function PowerPage() {
   );
   const yDomain = useMemo(() => calculateDomain(rows), [rows]);
   const report = useMemo(() => {
-    const r = calculatePowerReport(rows, range, displayDomain, offset);
+    const r = calculatePowerReport(
+      rows,
+      range,
+      displayDomain,
+      powerWindowLabel(range, offset),
+    );
     // Issue #131: overlay the cost totals fetched from /api/report onto
     // the in-memory report summary. The kWh integration runs client-side
     // from the rendered Power samples; the cost integration runs server-side
@@ -1258,7 +1004,10 @@ export default function PowerPage() {
           <button
             type="button"
             onClick={() => {
-              exportPowerCSV(calculatePowerReport(rows, range, displayDomain, offset), rows);
+              exportPowerCSV(
+                calculatePowerReport(rows, range, displayDomain, powerWindowLabel(range, offset)),
+                rows,
+              );
               setExportToast('CSV downloaded to your Downloads folder — ' + report.summary.periodLabel);
             }}
             disabled={loading || !hasData || Boolean(error)}
@@ -1269,7 +1018,10 @@ export default function PowerPage() {
           <button
             type="button"
             onClick={() => {
-              const result = exportPowerPDF(calculatePowerReport(rows, range, displayDomain, offset), rows);
+              const result = exportPowerPDF(
+                calculatePowerReport(rows, range, displayDomain, powerWindowLabel(range, offset)),
+                rows,
+              );
               setExportToast(
                 result === 'downloaded'
                   ? 'Consumption report downloaded to your Downloads folder — ' + report.summary.periodLabel

--- a/src/pages/PowerPage.tsx
+++ b/src/pages/PowerPage.tsx
@@ -51,6 +51,15 @@ interface PowerRow {
   gridPower: number | null;
   homePower: number | null;
   soc: number | null;
+  // Directional magnitudes (W, >= 0), pre-split server-side before bucket
+  // aggregation. The Consumption Report integrates / peaks these instead of
+  // re-splitting the net battery/grid power, which cancels charge against
+  // discharge (import against export) within a wide bucket. Null when a
+  // timestamp has no sample.
+  chargePower: number | null;
+  dischargePower: number | null;
+  gridImportPower: number | null;
+  gridExportPower: number | null;
 }
 
 interface PowerHistoryState {
@@ -59,7 +68,16 @@ interface PowerHistoryState {
   error: string;
 }
 
-const HISTORY_FIELDS = ['solar_power', 'battery_power', 'grid_power', 'home_power', 'soc'];
+// The net battery_power / grid_power drive the combined power CHART (one signed
+// line each). The directional `_charge_power` / `_discharge_power` /
+// `_grid_import_power` / `_grid_export_power` fields are split by sign on the
+// server BEFORE bucket aggregation and drive the Consumption Report's
+// directional energy + peak figures, so charge/discharge (import/export) no
+// longer cancel within a wide bucket.
+const HISTORY_FIELDS = [
+  'solar_power', 'battery_power', 'grid_power', 'home_power', 'soc',
+  '_charge_power', '_discharge_power', '_grid_import_power', '_grid_export_power',
+];
 const EMPTY_HISTORY_DATA: Record<string, TimePoint[]> = {};
 
 interface PowerBucket {
@@ -161,6 +179,10 @@ function buildPowerRows(data: Record<string, TimePoint[]>): PowerRow[] {
   const grid = pointsByTimestamp(data.grid_power);
   const home = pointsByTimestamp(data.home_power);
   const soc = pointsByTimestamp(data.soc);
+  const charge = pointsByTimestamp(data._charge_power);
+  const discharge = pointsByTimestamp(data._discharge_power);
+  const gridImport = pointsByTimestamp(data._grid_import_power);
+  const gridExport = pointsByTimestamp(data._grid_export_power);
   const timestamps = new Set<number>();
 
   for (const field of HISTORY_FIELDS) {
@@ -175,6 +197,10 @@ function buildPowerRows(data: Record<string, TimePoint[]>): PowerRow[] {
     const gridValue = grid.get(t);
     const homeValue = home.get(t);
     const socValue = soc.get(t);
+    const chargeValue = charge.get(t);
+    const dischargeValue = discharge.get(t);
+    const gridImportValue = gridImport.get(t);
+    const gridExportValue = gridExport.get(t);
 
     return {
       t,
@@ -183,6 +209,10 @@ function buildPowerRows(data: Record<string, TimePoint[]>): PowerRow[] {
       gridPower: gridValue == null ? null : -gridValue,
       homePower: homeValue == null ? null : Math.max(homeValue, 0),
       soc: socValue == null ? null : Math.min(100, Math.max(0, socValue)),
+      chargePower: chargeValue == null ? null : Math.max(chargeValue, 0),
+      dischargePower: dischargeValue == null ? null : Math.max(dischargeValue, 0),
+      gridImportPower: gridImportValue == null ? null : Math.max(gridImportValue, 0),
+      gridExportPower: gridExportValue == null ? null : Math.max(gridExportValue, 0),
     };
   });
 }
@@ -364,10 +394,6 @@ function positivePart(value: number | null | undefined): number {
   return Math.max(value ?? 0, 0);
 }
 
-function negativeMagnitude(value: number | null | undefined): number {
-  return Math.max(-(value ?? 0), 0);
-}
-
 function integratePair(
   a: number | null,
   b: number | null,
@@ -474,10 +500,14 @@ function calculatePowerReport(rows: PowerRow[], range: HistoryRange, domain: [nu
 
     const solar = integratePair(a.solarPower, b.solarPower, hours, positivePart);
     const home = integratePair(a.homePower, b.homePower, hours, positivePart);
-    const gridImport = integratePair(a.gridPower, b.gridPower, hours, positivePart);
-    const gridExport = integratePair(a.gridPower, b.gridPower, hours, negativeMagnitude);
-    const batteryCharge = integratePair(a.batteryPower, b.batteryPower, hours, negativeMagnitude);
-    const batteryDischarge = integratePair(a.batteryPower, b.batteryPower, hours, positivePart);
+    // Directional energy integrates the server-split magnitudes (already >= 0),
+    // not the net grid/battery power. Integrating the net would let a bucket's
+    // import and export (charge and discharge) cancel before integration - the
+    // same sign-cancellation the History directional charts had.
+    const gridImport = integratePair(a.gridImportPower, b.gridImportPower, hours, positivePart);
+    const gridExport = integratePair(a.gridExportPower, b.gridExportPower, hours, positivePart);
+    const batteryCharge = integratePair(a.chargePower, b.chargePower, hours, positivePart);
+    const batteryDischarge = integratePair(a.dischargePower, b.dischargePower, hours, positivePart);
 
     solarKwh += solar;
     homeKwh += home;
@@ -517,10 +547,13 @@ function calculatePowerReport(rows: PowerRow[], range: HistoryRange, domain: [nu
     batteryDischargeKwh,
     peakSolarW: Math.max(0, ...sortedRows.map((row) => positivePart(row.solarPower))),
     peakHomeW: Math.max(0, ...sortedRows.map((row) => positivePart(row.homePower))),
-    peakGridImportW: Math.max(0, ...sortedRows.map((row) => positivePart(row.gridPower))),
-    peakGridExportW: Math.max(0, ...sortedRows.map((row) => negativeMagnitude(row.gridPower))),
-    peakBatteryChargeW: Math.max(0, ...sortedRows.map((row) => negativeMagnitude(row.batteryPower))),
-    peakBatteryDischargeW: Math.max(0, ...sortedRows.map((row) => positivePart(row.batteryPower))),
+    // Peaks come from the directional magnitudes too (no net cancellation).
+    // These remain a max of per-bucket AVERAGES, so they understate the true
+    // instantaneous peak at coarse buckets - same as peakSolarW / peakHomeW.
+    peakGridImportW: Math.max(0, ...sortedRows.map((row) => positivePart(row.gridImportPower))),
+    peakGridExportW: Math.max(0, ...sortedRows.map((row) => positivePart(row.gridExportPower))),
+    peakBatteryChargeW: Math.max(0, ...sortedRows.map((row) => positivePart(row.chargePower))),
+    peakBatteryDischargeW: Math.max(0, ...sortedRows.map((row) => positivePart(row.dischargePower))),
     socMin,
     socMax,
     socAvg,

--- a/src/pages/powerReport.ts
+++ b/src/pages/powerReport.ts
@@ -1,0 +1,315 @@
+// ---------------------------------------------------------------------------
+// Power-page Consumption Report aggregation
+//
+// Pure helpers extracted from PowerPage.tsx so the bucket integration can be
+// unit-tested without rendering the React tree. The shape returned by
+// `calculatePowerReport` is what the Power page's "Consumption Report" button
+// shows; PR #166 changed the directional energy + peak fields to integrate
+// the server-derived `_charge_power` / `_discharge_power` /
+// `_grid_import_power` / `_grid_export_power` magnitudes instead of
+// re-splitting the net signed `battery_power` / `grid_power` on the client
+// (which would let charge and discharge cancel inside a wide bucket).
+// ---------------------------------------------------------------------------
+
+import type { HistoryRange } from '../lib/types';
+
+export interface PowerRow {
+  t: number;
+  solarPower: number | null;
+  batteryPower: number | null;
+  /** Grid power, negated relative to the backend so positive = importing. */
+  gridPower: number | null;
+  homePower: number | null;
+  soc: number | null;
+  /**
+   * Directional magnitudes (W, >= 0), pre-split server-side before bucket
+   * aggregation. The Consumption Report integrates / peaks these instead of
+   * re-splitting the net battery/grid power, which cancels charge against
+   * discharge (import against export) within a wide bucket. Null when a
+   * timestamp has no sample.
+   */
+  chargePower: number | null;
+  dischargePower: number | null;
+  gridImportPower: number | null;
+  gridExportPower: number | null;
+}
+
+export interface PowerBucket {
+  start: number;
+  label: string;
+  solarKwh: number;
+  homeKwh: number;
+  importKwh: number;
+  exportKwh: number;
+  batteryChargeKwh: number;
+  batteryDischargeKwh: number;
+  socMin: number | null;
+  socMax: number | null;
+  socSum: number;
+  socCount: number;
+}
+
+export interface PowerReportSummary {
+  periodLabel: string;
+  generatedAt: Date;
+  solarKwh: number;
+  homeKwh: number;
+  importKwh: number;
+  exportKwh: number;
+  netGridKwh: number;
+  batteryChargeKwh: number;
+  batteryDischargeKwh: number;
+  peakSolarW: number;
+  peakHomeW: number;
+  peakGridImportW: number;
+  peakGridExportW: number;
+  peakBatteryChargeW: number;
+  peakBatteryDischargeW: number;
+  socMin: number | null;
+  socMax: number | null;
+  socAvg: number | null;
+  solarCoveragePct: number | null;
+  gridDependencyPct: number | null;
+  // Issue #131: cost totals sourced from /api/report (server-side
+  // integration against the configured tariff + standing charge). When
+  // the fetch hasn't returned yet, these stay at 0 and the report tiles
+  // show "—" via the formatGbp fallback in the export rendering.
+  importCostGbp: number;
+  exportIncomeGbp: number;
+  netCostGbp: number;
+  standingChargeGbp: number;
+  standingChargePPerDay: number;
+  daysInRange: number;
+}
+
+export interface PowerReport {
+  summary: PowerReportSummary;
+  buckets: PowerBucket[];
+}
+
+/** Median of positive dt across `rows` (already-sorted by `t` not assumed). */
+export function medianIntervalMs(rows: PowerRow[]): number | null {
+  const intervals = rows
+    .slice(1)
+    .map((row, i) => row.t - rows[i].t)
+    .filter((dt) => dt > 0)
+    .sort((a, b) => a - b);
+  if (intervals.length === 0) return null;
+  return intervals[Math.floor(intervals.length / 2)];
+}
+
+/** Clamp to >= 0; treats null/undefined as 0. */
+export function positivePart(value: number | null | undefined): number {
+  return Math.max(value ?? 0, 0);
+}
+
+/**
+ * Trapezoidal energy in kWh between two readings `a` and `b`, spanning
+ * `hours` of time. `transform` is applied to each reading's value (e.g.
+ * [`positivePart`]) before integration so negative readings contribute
+ * zero rather than cancelling positive ones across the bucket boundary.
+ */
+export function integratePair(
+  a: number | null,
+  b: number | null,
+  hours: number,
+  transform: (value: number | null | undefined) => number,
+): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return transform(b) * hours / 1000;
+  if (b == null) return transform(a) * hours / 1000;
+  return ((transform(a) + transform(b)) / 2) * hours / 1000;
+}
+
+function bucketGranularity(range: HistoryRange): 'hour' | 'day' | 'month' {
+  if (range === '6m' || range === '1y') return 'month';
+  if (range === '7d' || range === '30d' || range === 'month') return 'day';
+  return 'hour';
+}
+
+function bucketStartMs(ts: number, range: HistoryRange): number {
+  const d = new Date(ts);
+  switch (bucketGranularity(range)) {
+    case 'month':
+      return new Date(d.getFullYear(), d.getMonth(), 1).getTime();
+    case 'day':
+      return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+    case 'hour':
+      return new Date(d.getFullYear(), d.getMonth(), d.getDate(), d.getHours()).getTime();
+  }
+}
+
+function bucketLabel(start: number, range: HistoryRange): string {
+  const d = new Date(start);
+  switch (bucketGranularity(range)) {
+    case 'month':
+      return d.toLocaleDateString([], { month: 'short', year: 'numeric' });
+    case 'day':
+      if (range === 'month') return String(d.getDate());
+      return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+    case 'hour':
+      return d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit' });
+  }
+}
+
+function emptyBucket(start: number, range: HistoryRange): PowerBucket {
+  return {
+    start,
+    label: bucketLabel(start, range),
+    solarKwh: 0,
+    homeKwh: 0,
+    importKwh: 0,
+    exportKwh: 0,
+    batteryChargeKwh: 0,
+    batteryDischargeKwh: 0,
+    socMin: null,
+    socMax: null,
+    socSum: 0,
+    socCount: 0,
+  };
+}
+
+function addSoc(bucket: PowerBucket, soc: number | null) {
+  if (soc == null) return;
+  bucket.socMin = bucket.socMin == null ? soc : Math.min(bucket.socMin, soc);
+  bucket.socMax = bucket.socMax == null ? soc : Math.max(bucket.socMax, soc);
+  bucket.socSum += soc;
+  bucket.socCount += 1;
+}
+
+/** Average SOC over the bucket's readings, or null if none. */
+export function bucketSocAvg(bucket: PowerBucket): number | null {
+  return bucket.socCount > 0 ? bucket.socSum / bucket.socCount : null;
+}
+
+/**
+ * Build the Consumption Report. Walks the row pairs in time order,
+ * integrates each direction's kWh via the trapezoidal rule on magnitudes,
+ * and groups the per-bucket totals by the range's granularity (hour for
+ * sub-day ranges, day for week/month, month for 6m/1y).
+ *
+ * The directional energy + peak figures (`importKwh`, `exportKwh`,
+ * `batteryChargeKwh`, `batteryDischargeKwh`, `peakGridImportW`, etc.)
+ * integrate the server-split magnitudes, NOT the net signed fields,
+ * so charge never cancels discharge within a wide bucket. The net
+ * `battery_power` / `grid_power` series on the chart are still signed
+ * (one line each, drawn as a connected signed waveform) - only the
+ * Consumption Report's directional sums switched (PR #166).
+ *
+ * `periodLabel` is supplied by the caller (typically
+ * `powerWindowLabel(range, offset)` from PowerPage) so this module
+ * stays free of UI/i18n dependencies and tests can pass `''`.
+ */
+export function calculatePowerReport(
+  rows: PowerRow[],
+  range: HistoryRange,
+  domain: [number, number],
+  periodLabel: string = '',
+): PowerReport {
+  const buckets = new Map<number, PowerBucket>();
+  const getBucket = (ts: number) => {
+    const start = bucketStartMs(ts, range);
+    const existing = buckets.get(start);
+    if (existing) return existing;
+    const created = emptyBucket(start, range);
+    buckets.set(start, created);
+    return created;
+  };
+
+  const sortedRows = rows.filter((row) => row.t >= domain[0] && row.t <= domain[1]).sort((a, b) => a.t - b.t);
+  const medianMs = medianIntervalMs(sortedRows);
+  const maxGapMs = medianMs == null ? Infinity : medianMs * 3.5;
+
+  let solarKwh = 0;
+  let homeKwh = 0;
+  let importKwh = 0;
+  let exportKwh = 0;
+  let batteryChargeKwh = 0;
+  let batteryDischargeKwh = 0;
+
+  for (let i = 0; i < sortedRows.length - 1; i++) {
+    const a = sortedRows[i];
+    const b = sortedRows[i + 1];
+    const rawDt = b.t - a.t;
+    if (rawDt <= 0 || rawDt > maxGapMs) continue;
+    const start = Math.max(a.t, domain[0]);
+    const end = Math.min(b.t, domain[1]);
+    const hours = (end - start) / 3600000;
+    if (hours <= 0) continue;
+
+    const solar = integratePair(a.solarPower, b.solarPower, hours, positivePart);
+    const home = integratePair(a.homePower, b.homePower, hours, positivePart);
+    // Directional energy integrates the server-split magnitudes (already >= 0),
+    // not the net grid/battery power. Integrating the net would let a bucket's
+    // import and export (charge and discharge) cancel before integration - the
+    // same sign-cancellation the History directional charts had.
+    const gridImport = integratePair(a.gridImportPower, b.gridImportPower, hours, positivePart);
+    const gridExport = integratePair(a.gridExportPower, b.gridExportPower, hours, positivePart);
+    const batteryCharge = integratePair(a.chargePower, b.chargePower, hours, positivePart);
+    const batteryDischarge = integratePair(a.dischargePower, b.dischargePower, hours, positivePart);
+
+    solarKwh += solar;
+    homeKwh += home;
+    importKwh += gridImport;
+    exportKwh += gridExport;
+    batteryChargeKwh += batteryCharge;
+    batteryDischargeKwh += batteryDischarge;
+
+    const midpoint = start + (end - start) / 2;
+    const bucket = getBucket(midpoint);
+    bucket.solarKwh += solar;
+    bucket.homeKwh += home;
+    bucket.importKwh += gridImport;
+    bucket.exportKwh += gridExport;
+    bucket.batteryChargeKwh += batteryCharge;
+    bucket.batteryDischargeKwh += batteryDischarge;
+  }
+
+  for (const row of sortedRows) {
+    addSoc(getBucket(row.t), row.soc);
+  }
+
+  const socValues = sortedRows.map((row) => row.soc).filter((soc): soc is number => soc != null);
+  const socMin = socValues.length ? Math.min(...socValues) : null;
+  const socMax = socValues.length ? Math.max(...socValues) : null;
+  const socAvg = socValues.length ? socValues.reduce((acc, soc) => acc + soc, 0) / socValues.length : null;
+
+  const summary: PowerReportSummary = {
+    periodLabel,
+    generatedAt: new Date(),
+    solarKwh,
+    homeKwh,
+    importKwh,
+    exportKwh,
+    netGridKwh: importKwh - exportKwh,
+    batteryChargeKwh,
+    batteryDischargeKwh,
+    peakSolarW: Math.max(0, ...sortedRows.map((row) => positivePart(row.solarPower))),
+    peakHomeW: Math.max(0, ...sortedRows.map((row) => positivePart(row.homePower))),
+    // Peaks come from the directional magnitudes too (no net cancellation).
+    // These remain a max of per-bucket AVERAGES, so they understate the true
+    // instantaneous peak at coarse buckets - same as peakSolarW / peakHomeW.
+    peakGridImportW: Math.max(0, ...sortedRows.map((row) => positivePart(row.gridImportPower))),
+    peakGridExportW: Math.max(0, ...sortedRows.map((row) => positivePart(row.gridExportPower))),
+    peakBatteryChargeW: Math.max(0, ...sortedRows.map((row) => positivePart(row.chargePower))),
+    peakBatteryDischargeW: Math.max(0, ...sortedRows.map((row) => positivePart(row.dischargePower))),
+    socMin,
+    socMax,
+    socAvg,
+    solarCoveragePct: homeKwh > 0 ? solarKwh / homeKwh * 100 : null,
+    gridDependencyPct: homeKwh > 0 ? importKwh / homeKwh * 100 : null,
+    // Issue #131: cost totals filled in by the HTTP layer once /api/report
+    // returns. Defaults are 0 so the report tiles can render immediately.
+    importCostGbp: 0,
+    exportIncomeGbp: 0,
+    netCostGbp: 0,
+    standingChargeGbp: 0,
+    standingChargePPerDay: 0,
+    daysInRange: 0,
+  };
+
+  return {
+    summary,
+    buckets: [...buckets.values()].sort((a, b) => a.start - b.start),
+  };
+}

--- a/tests/lib/powerReport.test.ts
+++ b/tests/lib/powerReport.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculatePowerReport,
+  integratePair,
+  positivePart,
+  type PowerRow,
+} from '../../src/pages/powerReport';
+
+// ---------------------------------------------------------------------------
+// Regression tests for the directional sign-cancellation bug fixed in
+// PR #166: the Consumption Report's directional energy + peak figures
+// must integrate / peak the server-split magnitudes (`chargePower` /
+// `dischargePower` / `gridImportPower` / `gridExportPower`), not re-split
+// the net signed `battery_power` / `grid_power` columns. Integrating the
+// net would let a bucket's import and export (charge and discharge) cancel
+// before integration, collapsing the directional sums toward 0.
+//
+// These tests pin:
+//   - the directional integration totals (the bug PR #166 closes)
+//   - the directional peak figures (max of per-row magnitudes)
+//   - the trapezoidal math via `integratePair` / `positivePart` directly
+//   - the route through `calculatePowerReport`, including bucket
+//     granularity (hour / day / month) and the max-gap filter
+//
+// The net `battery_power` / `grid_power` fields are NOT exercised - the
+// Consumption Report's directional math is intentionally independent of
+// them (they drive the chart, not the report).
+// ---------------------------------------------------------------------------
+
+/** Build a `PowerRow` with only the directional fields populated. */
+function row(t: number, override: Partial<PowerRow> = {}): PowerRow {
+  return {
+    t,
+    solarPower: null,
+    batteryPower: null,
+    gridPower: null,
+    homePower: null,
+    soc: null,
+    chargePower: null,
+    dischargePower: null,
+    gridImportPower: null,
+    gridExportPower: null,
+    ...override,
+  };
+}
+
+describe('powerReport — directional charge / discharge integration (PR #166)', () => {
+  it('integrates a mixed-direction battery series without cancellation', () => {
+    // Two readings 1h apart, the bucket fully inside the domain. Battery
+    // field is empty (the report's directional energy ignores it), but the
+    // directional series carries:
+    //   - charging 1500 W for the first half, 500 W for the second half
+    //   - discharging 800 W for the first half, 1200 W for the second half
+    // Trapezoidal:
+    //   batteryCharge    = ((1500+500)/2) * 1h / 1000  = 1.0  kWh
+    //   batteryDischarge = ((800+1200)/2) * 1h / 1000  = 1.0  kWh
+    // The OLD net-split code would have returned ~0 for both because the
+    // pre-bucket average of the signed net cancelled out.
+    const t0 = 1_700_000_000_000;
+    const rows: PowerRow[] = [
+      row(t0, {
+        chargePower: 1500,
+        dischargePower: 800,
+        gridImportPower: 100,
+        gridExportPower: 200,
+      }),
+      row(t0 + 3_600_000, {
+        chargePower: 500,
+        dischargePower: 1200,
+        gridImportPower: 300,
+        gridExportPower: 0,
+      }),
+    ];
+
+    const report = calculatePowerReport(rows, '1h', [t0 - 1, t0 + 3_600_001], 0, 'Test');
+
+    expect(report.summary.batteryChargeKwh).toBeCloseTo(1.0, 6);
+    expect(report.summary.batteryDischargeKwh).toBeCloseTo(1.0, 6);
+    expect(report.summary.importKwh).toBeCloseTo(0.2, 6);
+    expect(report.summary.exportKwh).toBeCloseTo(0.1, 6);
+  });
+
+  it('reports peak W from the directional magnitudes, not the net', () => {
+    // Two readings; charge peaks at 2500 W in the second reading,
+    // discharge peaks at 1800 W in the first.
+    const t0 = 1_700_100_000_000;
+    const rows: PowerRow[] = [
+      row(t0, { chargePower: 1000, dischargePower: 1800, gridImportPower: 5000 }),
+      row(t0 + 60_000, { chargePower: 2500, dischargePower: 1200, gridExportPower: 4200 }),
+    ];
+
+    const report = calculatePowerReport(rows, '1h', [t0 - 1, t0 + 60_001], 0, 'Test');
+
+    expect(report.summary.peakBatteryChargeW).toBe(2500);
+    expect(report.summary.peakBatteryDischargeW).toBe(1800);
+    expect(report.summary.peakGridImportW).toBe(5000);
+    expect(report.summary.peakGridExportW).toBe(4200);
+  });
+
+  it('does NOT let mixed-direction data cancel within one bucket', () => {
+    // Bypass the time-domain filter by stuffing everything into the same
+    // hour-bucket with 1-second spacing - the report has to walk each
+    // pair regardless of bucket structure. Two reads, battery in opposite
+    // directions: the OLD code's net split would have one direction equal
+    // to the magnitude and the other equal to zero. PR #166 splits before
+    // integration, so each direction sees its full magnitude independently.
+    const t0 = 1_700_200_000_000;
+    const dt = 1_000; // 1s between readings
+    const rows: PowerRow[] = [
+      row(t0, { chargePower: 2000, dischargePower: 0, gridImportPower: 3000, gridExportPower: 0 }),
+      row(t0 + dt, { chargePower: 0, dischargePower: 2000, gridImportPower: 0, gridExportPower: 3000 }),
+    ];
+
+    const report = calculatePowerReport(rows, '1h', [t0 - 1, t0 + dt + 1], 0, 'Test');
+
+    // Trapezoid of (2000, 0) over 1s with 1000-W reduction:
+    //   ((2000 + 0) / 2) * (1000ms / 3600000) / 1000 = 0.0002778 kWh
+    // (both directions contribute the same shape of trapzoid under
+    // positivePart, so both totals land on this small value.)
+    const expectedKwh = (2000 / 2) * (dt / 3_600_000) / 1000;
+    expect(report.summary.batteryChargeKwh).toBeGreaterThan(0);
+    expect(report.summary.batteryDischargeKwh).toBeGreaterThan(0);
+    expect(report.summary.batteryChargeKwh).toBeCloseTo(expectedKwh, 6);
+    expect(report.summary.batteryDischargeKwh).toBeCloseTo(expectedKwh, 6);
+    // Grid uses different magnitudes (3000 W), so its expected kWh differs:
+    //   ((3000 + 0) / 2) * (1000ms / 3600000) / 1000 = 0.0004167 kWh
+    const expectedGridKwh = (3000 / 2) * (dt / 3_600_000) / 1000;
+    expect(report.summary.importKwh).toBeCloseTo(expectedGridKwh, 6);
+    expect(report.summary.exportKwh).toBeCloseTo(expectedGridKwh, 6);
+  });
+
+  it('produces the same totals regardless of how readings are split across buckets', () => {
+    // Pin: bucketing is a display concern (per the chosen range's
+    // granularity); the summary totals integrate over the full domain.
+    // Two datasets that produce the same kWh after integration should
+    // give the same summary, regardless of where the bucket boundaries
+    // fall.
+    const t0 = 1_700_300_000_000;
+    const long: PowerRow[] = [
+      row(t0, { chargePower: 1000 }),
+      row(t0 + 3_600_000, { chargePower: 500 }),
+    ];
+    // Identical readings, but with a synthetic halfway sample that does
+    // not change the trapzoidal integral of the directional series.
+    const split: PowerRow[] = [
+      row(t0, { chargePower: 1000 }),
+      row(t0 + 1_800_000, { chargePower: 750 }),
+      row(t0 + 3_600_000, { chargePower: 500 }),
+    ];
+    const domain: [number, number] = [t0 - 1, t0 + 3_600_001];
+    const a = calculatePowerReport(long, '1h', domain, 0, 'A');
+    const b = calculatePowerReport(split, '1h', domain, 0, 'B');
+    expect(a.summary.batteryChargeKwh).toBeCloseTo(b.summary.batteryChargeKwh, 6);
+  });
+
+  it('does not sum pairs across a large gap in the readings', () => {
+    // Median-interval × 3.5 = maxGapMs: a gap more than 3.5× the typical
+    // interval is treated as a discontinuity and skipped. Build 5 rows so
+    // the median settles on the typical 1-minute interval - with only 2
+    // or 3 rows, the median can drift onto the gap itself and disable the
+    // filter (PR #166 doesn't change this; the median-of-N behaviour is
+    // pre-existing and just easier to reason about with N >= 5).
+    const t0 = 1_700_400_000_000;
+    const minute = 60_000;
+    const rows: PowerRow[] = [
+      row(t0, { chargePower: 2000 }),
+      row(t0 + minute, { chargePower: 2000 }),
+      row(t0 + 2 * minute, { chargePower: 2000 }),
+      row(t0 + 3 * minute, { chargePower: 2000 }),
+      // 2-week gap after the close cluster; the 4 close intervals settle
+      // the median at 1 minute, so 3.5× is ~3.5 minutes and the 2-week
+      // gap blows past the filter.
+      row(t0 + 3 * minute + 14 * 86_400_000, { chargePower: 2000 }),
+    ];
+    const report = calculatePowerReport(
+      rows,
+      '1y',
+      [t0 - 1, t0 + 3 * minute + 14 * 86_400_000 + 1],
+      0,
+      'Test',
+    );
+    // Three pairs integrate cleanly (4 close rows = 3 close pairs); the
+    // fourth pair (last close → far row) is skipped because the gap is
+    // too big. Trapezoid of (2000, 2000) over 1 min:
+    //   ((2000 + 2000) / 2) * (1 min / 60 min/hr) / 1000 = 0.0333 kWh each
+    // The sum across the 3 close pairs ≈ 3 × 0.0333 ≈ 0.1 kWh.
+    const perPairKwh = 2000 * (minute / 3_600_000) / 1000;
+    expect(report.summary.batteryChargeKwh).toBeCloseTo(perPairKwh * 3, 6);
+  });
+});
+
+describe('powerReport — primitives', () => {
+  it('positivePart clamps negatives to 0 and treats null as 0', () => {
+    expect(positivePart(5)).toBe(5);
+    expect(positivePart(-3)).toBe(0);
+    expect(positivePart(0)).toBe(0);
+    expect(positivePart(null)).toBe(0);
+    expect(positivePart(undefined)).toBe(0);
+  });
+
+  it('integratePair averages two readings × hours / 1000', () => {
+    // 1000 W + 0 W over 1 hour = 0.5 kWh.
+    expect(integratePair(1000, 0, 1, positivePart)).toBeCloseTo(0.5, 6);
+    // Constant 1000 W over 1 hour = 1 kWh.
+    expect(integratePair(1000, 1000, 1, positivePart)).toBeCloseTo(1.0, 6);
+    // Both null = 0.
+    expect(integratePair(null, null, 1, positivePart)).toBe(0);
+    // Single-sided: uses that side's value (avg = the value × hours).
+    expect(integratePair(null, 2000, 1, positivePart)).toBeCloseTo(2.0, 6);
+    expect(integratePair(1500, null, 1, positivePart)).toBeCloseTo(1.5, 6);
+  });
+
+  it('integratePair uses the transform before averaging (no sign cancellation)', () => {
+    // 2000 W and -2000 W over 1 hour WITHOUT the positivePart transform
+    // would trapzoidally average to 0, which is exactly the bug PR #166
+    // fixes. With positivePart, the trapzoid sees (2000, 0) over 1 hour
+    // → 1 kWh.
+    expect(integratePair(2000, -2000, 1, positivePart)).toBeCloseTo(1.0, 6);
+  });
+
+  it('calculatePowerReport returns zero reports for an empty input', () => {
+    const report = calculatePowerReport([], '24h', [0, 1], 0, 'Empty');
+    expect(report.summary.batteryChargeKwh).toBe(0);
+    expect(report.summary.batteryDischargeKwh).toBe(0);
+    expect(report.summary.importKwh).toBe(0);
+    expect(report.summary.exportKwh).toBe(0);
+    expect(report.summary.solarKwh).toBe(0);
+    expect(report.summary.homeKwh).toBe(0);
+    expect(report.buckets).toEqual([]);
+    // Coverage / dependency percentages are null when there is no load.
+    expect(report.summary.solarCoveragePct).toBeNull();
+    expect(report.summary.gridDependencyPct).toBeNull();
+  });
+});

--- a/tests/pages/historyPageDirectionalFields.test.tsx
+++ b/tests/pages/historyPageDirectionalFields.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks — HistoryPage pulls in api (fetchHistory + apiGet), the Zustand
+// store, the chart library, and several helpers. Stub the side-effecting
+// pieces and capture the fetchHistory calls so we can assert the
+// directional-field wiring (PR #166).
+// ---------------------------------------------------------------------------
+
+type FetchHistoryCall = {
+  range: string;
+  fields: string[];
+  offset: number;
+};
+
+const fetchHistoryCalls: FetchHistoryCall[] = [];
+const fetchHistoryMock = vi.fn(
+  async (...args: unknown[]) => {
+    const [range, fields, offset] = args as [string, string[], number];
+    fetchHistoryCalls.push({ range, fields, offset });
+    return {};
+  },
+);
+
+const apiGetMock = vi.fn(async () => ({ ok: true, data: {} }));
+
+vi.mock('../../src/lib/api', () => ({
+  apiGet: (...args: unknown[]) => {
+    const [path] = args as [string];
+    return apiGetMock(path);
+  },
+  fetchHistory: (...args: unknown[]) => fetchHistoryMock(...args),
+  getApiBase: () => 'http://localhost:7337',
+  getServerPort: () => 7337,
+  isTauri: false,
+}));
+
+// Imported after the vi.mock() calls above.
+import HistoryPage from '../../src/pages/HistoryPage';
+import { useInverterStore } from '../../src/store/useInverterStore';
+
+function silenceConsoleError() {
+  return vi.spyOn(console, 'error').mockImplementation(() => {});
+}
+
+/**
+ * Switch the History tab by clicking its button. The default tab is
+ * 'battery' so we don't need to click anything for that one.
+ */
+async function clickTab(label: string) {
+  const btn = await screen.findByRole('button', { name: label, exact: true });
+  fireEvent.click(btn);
+}
+
+describe('<HistoryPage/> — directional power field wiring (PR #166)', () => {
+  beforeEach(() => {
+    silenceConsoleError();
+    fetchHistoryCalls.length = 0;
+    fetchHistoryMock.mockClear();
+    apiGetMock.mockClear();
+    // Reset the persisted chart range so each test starts on a known default.
+    useInverterStore.setState({
+      snapshot: null,
+      chartRange: '24h',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  describe('Battery tab', () => {
+    it('requests _charge_power and _discharge_power on the chart', async () => {
+      render(<HistoryPage />);
+      await waitFor(() => {
+        expect(fetchHistoryCalls.length).toBeGreaterThan(0);
+      });
+      // Find a call that includes the Battery tab's charge / discharge
+      // chart fields. Multiple calls may be issued per render cycle (one
+      // per rolling state), so look at every one.
+      const fieldsUsed = new Set(fetchHistoryCalls.flatMap((c) => c.fields));
+      expect(fieldsUsed.has('_charge_power')).toBe(true);
+      expect(fieldsUsed.has('_discharge_power')).toBe(true);
+    });
+
+    it('no longer requests the raw battery_power for the directional chart', async () => {
+      // PR #166 dropped the client-side `transform` flag from the Battery
+      // tab's power chart and pointed it at the new server-derived
+      // directional series. The raw `battery_power` is still on the
+      // whitelist but is no longer requested by this chart.
+      render(<HistoryPage />);
+      await waitFor(() => {
+        expect(fetchHistoryCalls.length).toBeGreaterThan(0);
+      });
+      const fieldsUsed = new Set(fetchHistoryCalls.flatMap((c) => c.fields));
+      expect(fieldsUsed.has('battery_power')).toBe(false);
+    });
+  });
+
+  describe('Grid tab', () => {
+    it('requests _grid_import_power and _grid_export_power on the chart', async () => {
+      render(<HistoryPage />);
+      await clickTab('Grid');
+      await waitFor(() => {
+        // The tab switch triggers a new fetch; spin until the grid
+        // directional fields appear in some call.
+        const fieldsUsed = new Set(fetchHistoryCalls.flatMap((c) => c.fields));
+        expect(fieldsUsed.has('_grid_import_power')).toBe(true);
+      });
+      const fieldsUsed = new Set(fetchHistoryCalls.flatMap((c) => c.fields));
+      expect(fieldsUsed.has('_grid_export_power')).toBe(true);
+    });
+
+    it('no longer requests the raw grid_power for the directional chart', async () => {
+      render(<HistoryPage />);
+      await clickTab('Grid');
+      // Spin until fetchHistory has had a chance to re-fire with the Grid
+      // tab's chart field list. We assert the field is *never* present.
+      await waitFor(() => {
+        expect(fetchHistoryCalls.length).toBeGreaterThan(1);
+      });
+      const fieldsUsed = new Set(fetchHistoryCalls.flatMap((c) => c.fields));
+      expect(fieldsUsed.has('grid_power')).toBe(false);
+    });
+  });
+
+  describe('tab isolation', () => {
+    it('does not request battery-side fields when on the Grid tab', async () => {
+      render(<HistoryPage />);
+      // Let the initial Battery fetch fire, then snapshot the call count
+      // so the post-tab-switch assertion only inspects the Grid-side calls.
+      await waitFor(() => {
+        expect(fetchHistoryCalls.length).toBeGreaterThan(0);
+      });
+      const callsBeforeGrid = fetchHistoryCalls.length;
+      await clickTab('Grid');
+      await waitFor(() => {
+        expect(fetchHistoryCalls.length).toBeGreaterThan(callsBeforeGrid);
+      });
+      // Slice off the pre-switch calls; only inspect calls fired after the
+      // Grid tab was activated.
+      const gridCalls = fetchHistoryCalls.slice(callsBeforeGrid);
+      const gridFields = new Set(gridCalls.flatMap((c) => c.fields));
+      expect(gridFields.has('_charge_power')).toBe(false);
+      expect(gridFields.has('_discharge_power')).toBe(false);
+    });
+
+    it('does not request grid-side fields when on the Battery tab', async () => {
+      render(<HistoryPage />);
+      // Default tab is Battery; just wait for the initial fetch.
+      await waitFor(() => {
+        expect(fetchHistoryCalls.length).toBeGreaterThan(0);
+      });
+      const fieldsUsed = new Set(fetchHistoryCalls.flatMap((c) => c.fields));
+      expect(fieldsUsed.has('_grid_import_power')).toBe(false);
+      expect(fieldsUsed.has('_grid_export_power')).toBe(false);
+    });
+  });
+
+  // Sanity: if no fetch happens at all, the field-list assertions above
+  // silently no-op. Pin that fetchHistory fires on mount so we know the
+  // page rendered far enough to query the API.
+  it('fires at least one fetchHistory call on mount', async () => {
+    render(<HistoryPage />);
+    await waitFor(() => {
+      expect(fetchHistoryCalls.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
I noticed this after backfilling all data from my inverter using the GivEnergy Cloud API.

## Problem
The History "Charge / Discharge Power" and "Grid Power" charts, plus the
Power-page Consumption Report, derived each direction by splitting a single
signed field (`battery_power` / `grid_power`) by sign **on the client** - after
the server had already `AVG`-aggregated it to one net value per bucket. So
within a bucket, charging and discharging (import and export) cancelled before
the split ever happened.

It's zoom-dependent: 24h buckets (1-year view) blend a whole day's charge and
discharge to a near-zero net, flat-lining both series; 12h buckets (6-month
view) only looked correct because a half-day is mostly one-directional. The
stored data is correct - only the chart/report misrepresented it.

## Fix
Derive the directional quantities **on the server**, averaging each direction's
magnitude independently per bucket via `AVG(CASE WHEN ...)`, so the sign split
happens before aggregation. Mirrors the existing `_import_cost` /
`_export_income` derive-then-downsample pattern.

- New fields `_charge_power` / `_discharge_power` / `_grid_import_power` /
  `_grid_export_power`, routed through `query_history` (a fixed name->constant-SQL
  map, so they bypass the column whitelist safely; injection-guard test included).
- History charts point at the new fields; client-side `transform` sign-splits removed.
- Power-page Consumption Report integrates/peaks the directional fields.

Impact on the Consumption Report at 1y was large - e.g. yearly battery charge
was understated ~14x (160 -> 2,324 kWh) and grid import by ~51% (1,169 -> 1,768 kWh),
all energy the old net-split zeroed out.

## Scope / follow-up
Peak-W figures remain a max of per-bucket averages (unchanged semantics); true
instantaneous peaks would need `MAX` aggregation and are intentionally left out.

## Before / after
<img width="1792" height="536" alt="image" src="https://github.com/user-attachments/assets/c9cfdfab-2430-4a90-b8ff-43fe64e6a7b5" />

<img width="1792" height="536" alt="image" src="https://github.com/user-attachments/assets/3737aa88-5c27-42e0-8eb2-91cac8923b95" />

