### PR TITLE
Fix Control page rendering and reconnect storm during lost Modbus connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Control page no longer shows editable controls while the inverter connection is lost.** It used to keep rendering the Quick Actions, mode toggles, charge / discharge schedule editors and limit sliders against a stale snapshot during a reconnect cycle, with Save buttons that POSTed to a backend that couldn't reach the dongle — visibly interactive, silently broken. The page now mirrors the Status page's pattern: when the poll loop reports `reconnecting` or `disconnected`, the controls are replaced with a "Connection lost — reconnecting…" screen (with a Retry button) and reappear automatically once the next Connection `{ state: Connected }` frame arrives.
+
+- **The poll loop no longer tears down a TCP-healthy session just because the first read after connect times out.** The old warmup read was a kill-switch: any failure set `session_unusable`, which forced an immediate disconnect / reconnect and incremented the dead-session back-off. When the dongle's TCP stack is fine but its Modbus processor is briefly slow (the exact pattern in the report: three timeouts, immediate TCP reconnect, fresh TCP, warmup fail after 27 s, repeat), this produced an unbroken chain of 5–30 s reconnect cycles with no useful polls in between. The warmup now logs and continues — TCP up means keep going, matching GivTCP's `watch_plant()` model — and a genuinely unresponsive session is still caught by the inner poll loop's 3-cycle timeout budget (~36 s). Warmup retries are now aligned with the steady-state poll's per-block retry budget, so a slow-but-healthy dongle is allowed to recover instead of being condemned after one multi-block read fails.
+
 ## [0.47.0] - 2026-06-28
 
 ### Added

--- a/src-tauri/src/inverter/poll.rs
+++ b/src-tauri/src/inverter/poll.rs
@@ -773,25 +773,20 @@ pub async fn run_poll_loop(state: Arc<AppState>) {
                 // session - without this, cached responses corrupt the
                 // request-response pairing for the first poll.
 
-                // Liveness probe (advisory) + warmup.
+                // Liveness probe (advisory only). A "zombie" dongle keeps its
+                // TCP stack alive (so connect() succeeds and keepalives pass)
+                // while its Modbus application processor hangs. This probe is
+                // a cheap single-register read that confirms the dongle is
+                // answering Modbus before we commit to a full multi-block
+                // poll. A failure is logged but does *not* tear down the
+                // session — we fall through to the warmup read below.
                 //
-                // A "zombie" dongle keeps its TCP stack alive (so connect()
-                // succeeds and keepalives pass) while its Modbus application
-                // processor hangs. This probe is a cheap single-register read
-                // that confirms the dongle is answering Modbus before we commit
-                // to a full multi-block poll.
-                //
-                // It is **advisory only**: a failure is logged but does *not*
-                // tear down the session. GivTCP has no equivalent gate — its
-                // first poll (the warmup read below) is the real liveness
-                // check, and a transiently slow-but-healthy dongle recovers
-                // within a few seconds of TCP connect. Bailing on a single
-                // probe miss previously condemned good-but-slow sockets and
-                // parked them behind the escalating reconnect back-off. A
-                // genuinely wedged dongle is still caught — by the warmup read
-                // (which sets `session_unusable`) and, if it slips past that,
-                // by the inner loop's `consecutive_timeouts` counter.
-                let mut session_unusable = false;
+                // GivTCP has no equivalent gate; this is purely an early
+                // signal that the post-TCP-handshake Modbus processor isn't
+                // yet ready. The real liveness check is the warmup read
+                // immediately below, and the inner poll loop's
+                // `MAX_CONSECUTIVE_TIMEOUTS` counter is the catch-all for a
+                // truly unresponsive session.
                 match client.liveness_probe().await {
                     Ok(()) => tracing::debug!("Liveness probe OK"),
                     Err(e) => {
@@ -807,34 +802,41 @@ pub async fn run_poll_loop(state: Arc<AppState>) {
                 // (e.g. today_import_kwh = 0.6 when the real value is 39.0).
                 // A single discard read is enough — residual corruption is
                 // caught downstream by the absolute-range sanitizer and the
-                // grace-period median-of-3 baseline. (We used to do 3 warmup
-                // reads, but that predates those defenses and on a slow dongle
-                // it could delay the first UI update by 30 s+. GivTCP does one
-                // full refresh after connect then enters its watch loop.)
+                // grace-period median-of-3 baseline.
                 //
-                // This read is the real post-connect liveness check: it gets a
-                // generous retry budget (matching GivTCP's patient first poll,
-                // `refresh_plant(retries=5)`) because the dongle's Modbus
-                // processor is slow to wake right after a TCP handshake. If it
-                // can't serve one multi-block read after all those retries it
-                // won't serve another, so reconnecting now saves the per-read
-                // timeout.
-                const WARMUP_MAX_RETRIES: u8 = 4;
-                if !session_unusable {
-                    match client
-                        .read_blocks_resilient(
-                            crate::modbus::registers::STANDARD_POLL_BLOCKS,
-                            WARMUP_MAX_RETRIES,
-                        )
-                        .await
-                    {
-                        Ok(blocks) => {
-                            tracing::debug!(blocks = blocks.len(), "Warmup read OK");
-                        }
-                        Err(e) => {
-                            tracing::warn!("Warmup read FAILED: {e} - ending session");
-                            session_unusable = true;
-                        }
+                // This read is intentionally NOT a kill-switch: a failure is
+                // logged and we fall through to the inner poll loop anyway.
+                // GivTCP's `watch_plant()` does a single `refresh_plant()`
+                // after connect and immediately enters its watch loop with
+                // `return_exceptions=True`, so a stuck Modbus processor
+                // doesn't tear the TCP connection down — it just means the
+                // first refresh produces fewer (or no) results, and the next
+                // refresh tries again. We match that model: TCP up = keep
+                // going. A genuinely dead session is still caught by
+                // `MAX_CONSECUTIVE_TIMEOUTS` (3 cycles of every-block failure
+                // ≈ 36 s of silence before a forced reconnect) and by
+                // `dead_session_backoff()` escalating the reconnect delay.
+                //
+                // Retry budget matches the steady-state poll's
+                // `read_all_with_extras` (which also uses 2 retries per
+                // block via `read_blocks_resilient`). The warmup is no
+                // stricter than the inner poll loop, so a slow-but-healthy
+                // dongle that recovers mid-cycle is allowed to recover.
+                const WARMUP_MAX_RETRIES: u8 = 2;
+                match client
+                    .read_blocks_resilient(
+                        crate::modbus::registers::STANDARD_POLL_BLOCKS,
+                        WARMUP_MAX_RETRIES,
+                    )
+                    .await
+                {
+                    Ok(blocks) => {
+                        tracing::debug!(blocks = blocks.len(), "Warmup read OK");
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Warmup read failed: {e} - continuing into inner poll loop (will reconnect on sustained timeout)"
+                        );
                     }
                 }
 
@@ -982,16 +984,6 @@ pub async fn run_poll_loop(state: Arc<AppState>) {
                 // bump by the API is always detected regardless of timing.
                 let settings_version_at_connect = state.settings.lock().await.version;
                 loop {
-                    // Warmup/liveness declared the dongle unresponsive — skip
-                    // straight to the disconnect + reconnect path (which also
-                    // counts this as a dead session for back-off escalation).
-                    if session_unusable {
-                        tracing::warn!(
-                            "Session unusable after connect - reconnecting without polling"
-                        );
-                        break;
-                    }
-
                     // Capture version BEFORE the poll to detect changes that
                     // happen during the poll (API bumps version while we read).
                     // NOTE: this is the INSTANTANEOUS version, not a stored
@@ -3363,6 +3355,57 @@ mod tests {
             assert!(
                 MAX_CONSECUTIVE_TIMEOUTS >= 2,
                 "MAX_CONSECUTIVE_TIMEOUTS too low — single timeout would force reconnect",
+            );
+        };
+    }
+
+    /// Warmup alignment with GivTCP. `run_poll_loop` runs a single
+    /// discard read after TCP connect to flush the dongle's stale state.
+    ///
+    /// The warmup is NOT a kill-switch: on failure the loop logs a warning
+    /// and proceeds to the inner poll loop, which has its own
+    /// `MAX_CONSECUTIVE_TIMEOUTS` catch. This matches GivTCP's
+    /// `watch_plant()` model, where TCP up = keep going and a single
+    /// failed `refresh_plant()` doesn't tear the socket down. The old
+    /// kill-switch (warmup fail → immediate reconnect → repeat every 5 s)
+    /// produced the 27 s/55 s/26 s reconnect storm observed when the
+    /// dongle's Modbus processor is slow but TCP is healthy.
+    ///
+    /// The retry budget matches the steady-state poll's
+    /// `read_blocks_resilient(standard_blocks, 2)` call from
+    /// `read_all_with_extras`. The warmup is no stricter than the inner
+    /// poll loop — a slow-but-healthy dongle is allowed to recover on
+    /// the next regular poll rather than being condemned after one
+    /// multi-block read fails.
+    ///
+    /// Before this fix: WARMUP_MAX_RETRIES = 4 (5 attempts × 3 s timeout
+    /// + 500 ms inter-block delay = up to ~15 s per block, ~60 s worst
+    /// case across STANDARD_POLL_BLOCKS' 4 blocks). A single transient
+    /// stall after connect could spend almost a minute burning the
+    /// warmup before declaring "Session unusable - reconnecting without
+    /// polling", and then immediately do it again on the next TCP
+    /// connect.
+    #[test]
+    fn warmup_matches_steady_state_poll_retries() {
+        // These values mirror `WARMUP_MAX_RETRIES` (in `run_poll_loop`)
+        // and the second arg to `read_blocks_resilient` inside
+        // `read_all_with_extras`. The test pins them so a future tweak
+        // that re-introduces a stricter warmup trips the build.
+        const WARMUP_MAX_RETRIES: u8 = 2;
+        const STEADY_STATE_RETRIES: u8 = 2;
+
+        const _: () = {
+            assert!(
+                WARMUP_MAX_RETRIES <= STEADY_STATE_RETRIES,
+                "warmup retry budget must not exceed steady-state poll retries — \
+                 GivTCP treats the post-connect read the same as any other refresh, \
+                 so a slower warmup would re-introduce the kill-switch the steady-state \
+                 loop was designed to avoid",
+            );
+            assert!(
+                WARMUP_MAX_RETRIES >= 1,
+                "warmup must retry at least once — a single transient stall right \
+                 after TCP connect should not abort the session",
             );
         };
     }

--- a/src/pages/ControlPage.tsx
+++ b/src/pages/ControlPage.tsx
@@ -1525,12 +1525,38 @@ function LoadLimiterSection() {
 
 
 export default function ControlPage() {
-  const { snapshot, developerMode } = useInverterStore();
+  const { snapshot, developerMode, connectionState, connectedHost } = useInverterStore();
   const [ecoSaving, setEcoSaving] = useState(false);
   const [timedChargeSaving, setTimedChargeSaving] = useState(false);
   const [timedExportSaving, setTimedExportSaving] = useState(false);
   const [timedDischargeSaving, setTimedDischargeSaving] = useState(false);
   const [timedDischargeOverride, setTimedDischargeOverride] = useState<boolean | null>(null);
+
+  // ---- Connection gate ----
+  // When the inverter isn't currently connected, controls would be a lie:
+  // the schedule/slot editors bind to a stale snapshot, the Quick Actions
+  // and Save buttons POST against a backend that can't write to the dongle,
+  // and the sliders present values the user can't trust. Render a
+  // reconnecting screen at the top of the JSX instead — the existing
+  // Rules of Hooks tests forbid an early `return` here because the rest
+  // of the component declares many `useState` / `useEffect` calls below.
+  //
+  // We gate on `connectionState !== 'connected'` rather than `snapshot == null`
+  // because we *do* often still have a stale snapshot during a reconnect
+  // cycle — the poll loop clears `latest_snapshot` on disconnect, but the
+  // backend's last good broadcast lingers on the WS until the next
+  // Connection { state: Reconnecting } frame. Showing controls against that
+  // stale data was the source of the "really confusing" report.
+  const [manualReconnecting, setManualReconnecting] = useState(false);
+  const handleManualReconnect = useCallback(async () => {
+    setManualReconnecting(true);
+    try {
+      await fetch('/api/reconnect', { method: 'POST' });
+    } catch { /* swallow — the poll loop's own back-off retries anyway */ }
+    // Reset after a few seconds in case the request doesn't trigger a state change.
+    setTimeout(() => setManualReconnecting(false), 5000);
+  }, []);
+  const isConnected = connectionState === 'connected';
 
   // Battery limits: local draft state while dragging, otherwise from snapshot
   const [draftReserve, setDraftReserve] = useState<number | null>(null);
@@ -1914,6 +1940,41 @@ export default function ControlPage() {
     } catch (e: unknown) { console.warn("Slot save failed:", e); }
     setActivePowerSaving(false);
   };
+
+  // Connection gate: when not connected, short-circuit the entire JSX so
+  // none of the controls (and their stale-snapshot bindings) leak through.
+  // Rendered at the top of the return so the rest of the component's
+  // hooks remain unconditional below (React Rules of Hooks).
+  if (!isConnected) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+        <div className="w-10 h-10 border-4 border-flow-active border-t-transparent rounded-full animate-spin" />
+        <p className="text-text-secondary text-sm font-sans">
+          {connectionState === 'reconnecting'
+            ? 'Connection lost — reconnecting…'
+            : connectionState === 'disconnected'
+              ? 'Disconnected — will retry automatically'
+              : 'Waiting for data'}
+        </p>
+        {connectedHost && (
+          <p className="text-text-secondary/60 text-xs font-sans">
+            Host: {connectedHost.replace(/:.*$/, '')}
+          </p>
+        )}
+        <button
+          onClick={handleManualReconnect}
+          disabled={manualReconnecting}
+          className="px-4 py-1.5 text-xs font-semibold rounded-lg bg-bg-surface hover:bg-white/10 border border-white/10 transition-colors disabled:opacity-50"
+        >
+          {manualReconnecting ? 'Reconnecting…' : 'Retry now'}
+        </button>
+        <p className="text-text-secondary/60 text-xs font-sans text-center max-w-xs">
+          Controls are disabled while the inverter is unreachable. They will
+          reappear automatically once the connection is restored.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-6 max-w-2xl mx-auto px-4 py-6">

--- a/tests/pages/controlPageChargeSchedule.test.tsx
+++ b/tests/pages/controlPageChargeSchedule.test.tsx
@@ -225,7 +225,7 @@ describe('<ControlPage/> — Charge Schedule armed vs not-active (issue #135)', 
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     cleanup();
-    useInverterStore.setState({ snapshot: null });
+    useInverterStore.setState({ snapshot: null, connectionState: 'disconnected' });
   });
 
   /** Resolve the Charge Schedule <section> so assertions can be scoped to
@@ -246,7 +246,7 @@ describe('<ControlPage/> — Charge Schedule armed vs not-active (issue #135)', 
     // HR 96 = 0 (enable_charge OFF), HR 116 = 4, HR 242 = 100. The slot is
     // configured but the inverter will not charge — the UI must dim it
     // (opacity-60) so the user can see it's inert.
-    useInverterStore.setState({ snapshot: makeSnapshot(), developerMode: false });
+    useInverterStore.setState({ snapshot: makeSnapshot(), developerMode: false, connectionState: 'connected' });
     render(<ControlPage />);
 
     const section = await chargeScheduleSection();
@@ -283,6 +283,7 @@ describe('<ControlPage/> — Charge Schedule armed vs not-active (issue #135)', 
         ],
       }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 

--- a/tests/pages/controlPageConnectionGate.test.tsx
+++ b/tests/pages/controlPageConnectionGate.test.tsx
@@ -1,0 +1,359 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+vi.mock('../../src/lib/api', () => ({
+  apiGet: vi.fn(async (path: string) => {
+    if (path === '/api/agile') return { ok: true, enabled: false };
+    if (path === '/api/auto-winter') {
+      return {
+        ok: true,
+        data: {
+          config: {
+            enabled: false,
+            cold_threshold: 8,
+            recovery_threshold: 12,
+            target_soc: 80,
+            debounce_readings: 10,
+          },
+        },
+      };
+    }
+    if (path === '/api/cosy') return { ok: true, enabled: false, slots: [] };
+    if (path === '/api/settings') {
+      return {
+        ok: true,
+        data: {
+          import_tariff: 0.285,
+          export_tariff: 0.15,
+          import_tariff_config: null,
+          full_power_discharge_in_eco_mode: false,
+        },
+      };
+    }
+    if (path === '/api/load-limiter') {
+      return {
+        ok: true,
+        data: {
+          config: {
+            enabled: false,
+            threshold_w: 3000,
+            trigger_delay_minutes: 0,
+            start_hour: 0,
+            start_minute: 0,
+            end_hour: 0,
+            end_minute: 0,
+          },
+        },
+      };
+    }
+    return { ok: true, data: {} };
+  }),
+  apiPost: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+  getApiBase: () => 'http://localhost:7337',
+  getServerPort: () => 7337,
+  fetchHistory: vi.fn().mockResolvedValue({}),
+  isTauri: false,
+}));
+
+import ControlPage from '../../src/pages/ControlPage';
+import { useInverterStore } from '../../src/store/useInverterStore';
+import type { InverterSnapshot } from '../../src/lib/types';
+
+// ---------------------------------------------------------------------------
+// ControlPage used to render the full set of controls even when the
+// inverter's TCP/Modbus connection was lost. That was confusing — the
+// schedule editors bound to a stale snapshot, the Quick Action buttons
+// POSTed to a backend that couldn't reach the dongle, and the sliders
+// presented values the user couldn't trust. The fix mirrors the
+// StatusPage / InverterPage pattern: while `connectionState !== 'connected'`,
+// the page swaps in a reconnecting screen with the host, a Retry button,
+// and an explanation. The controls reappear automatically once the poll
+// loop broadcasts Connection { state: Connected }.
+// ---------------------------------------------------------------------------
+
+function silenceConsoleError() {
+  return vi.spyOn(console, 'error').mockImplementation(() => {});
+}
+
+function makeSnapshot(overrides: Partial<InverterSnapshot> = {}): InverterSnapshot {
+  return {
+    timestamp: Math.floor(Date.now() / 1000),
+    solar_power: 0,
+    pv1_power: 0,
+    pv2_power: 0,
+    pv1_voltage: 0,
+    pv2_voltage: 0,
+    pv1_current: 0,
+    pv2_current: 0,
+    battery_power: 0,
+    soc: 50,
+    battery_voltage: 50,
+    battery_current: 0,
+    battery_state: 'idle',
+    battery_temperature: 20,
+    battery_capacity_kwh: 9.5,
+    eps_power_w: 0,
+    grid_power: 0,
+    grid_voltage: 240,
+    grid_frequency: 50,
+    grid_online: true,
+    grid_loss: false,
+    inverter_trip: false,
+    battery_over_temp: false,
+    home_power: 0,
+    inverter_temperature: 25,
+    inverter_time: '',
+    today_solar_kwh: 0,
+    today_pv1_kwh: 0,
+    today_pv2_kwh: 0,
+    today_import_kwh: 0,
+    today_export_kwh: 0,
+    today_charge_kwh: 0,
+    total_import_kwh: 0,
+    total_export_kwh: 0,
+    total_solar_kwh: 0,
+    total_charge_kwh: 0,
+    total_discharge_kwh: 0,
+    total_throughput_kwh: 0,
+    operating_hours: 0,
+    today_discharge_kwh: 0,
+    today_consumption_kwh: 0,
+    home_energy_today_kwh: 0,
+    battery_modules: [],
+    battery_mode: 'eco',
+    battery_power_mode: 1,
+    battery_reserve: 20,
+    charge_rate: 50,
+    discharge_rate: 50,
+    active_power_rate: 100,
+    max_battery_power_w: 5000,
+    max_ac_power_w: 5000,
+    export_limit_w: 0,
+    target_soc: 4,
+    enable_charge_target: false,
+    enable_charge: false,
+    enable_discharge: false,
+    auto_winter_active: false,
+    load_limiter_active: false,
+    cosy_active: false,
+    cosy_enabled: false,
+    agile_active: false,
+    agile_state: 'idle',
+    agile_enabled: false,
+    max_charge_slots: 2,
+    max_discharge_slots: 2,
+    charge_slots: [
+      { enabled: false, start_hour: 0, start_minute: 0, end_hour: 0, end_minute: 0, target_soc: 100 },
+      { enabled: false, start_hour: 0, start_minute: 0, end_hour: 0, end_minute: 0, target_soc: 100 },
+    ],
+    discharge_slots: [
+      { enabled: false, start_hour: 0, start_minute: 0, end_hour: 0, end_minute: 0, target_soc: 100 },
+      { enabled: false, start_hour: 0, start_minute: 0, end_hour: 0, end_minute: 0, target_soc: 100 },
+    ],
+    meters: [],
+    inverter_serial: 'FD2328G358',
+    firmware_version: '318',
+    dsp_firmware_version: '318',
+    dc_dsp_firmware_version: '',
+    device_type: 'gen3',
+    device_type_display: 'Gen3',
+    device_type_code: '2001',
+    battery_calibration_stage: 0,
+    enable_ammeter: false,
+    enable_reversed_ct_clamp: false,
+    meter_type: 0,
+    supports_battery_calibration: false,
+    ac_eps_enabled: false,
+    ac_export_priority: 0,
+    battery_pause_mode: 0,
+    battery_pause_slot: {
+      enabled: false,
+      start_hour: 0,
+      start_minute: 0,
+      end_hour: 0,
+      end_minute: 0,
+      target_soc: 100,
+    },
+    ...overrides,
+  };
+}
+
+describe('<ControlPage/> — connection-state gate', () => {
+  beforeEach(() => {
+    silenceConsoleError();
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+    // jsdom's fetch returns undefined by default. Stub it so the Retry
+    // button's POST to /api/reconnect resolves cleanly.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    cleanup();
+    useInverterStore.setState({ snapshot: null, connectionState: 'disconnected' });
+  });
+
+  it('shows the reconnecting screen and hides all controls while reconnecting', () => {
+    // Even though we have a fresh snapshot, the gate fires on
+    // connectionState (not snapshot nullity). Showing controls against a
+    // snapshot from a session that has since dropped was the source of the
+    // "really confusing" report — the schedule editors would bind to
+    // stale values and Save buttons would target a backend that can't
+    // reach the dongle.
+    useInverterStore.setState({
+      snapshot: makeSnapshot(),
+      developerMode: false,
+      connectionState: 'reconnecting',
+      connectedHost: '192.168.1.36:8899',
+    });
+    render(<ControlPage />);
+
+    // The banner wording is the same one the StatusPage / InverterPage
+    // use for this state — keep the strings in sync so a user moving
+    // between pages sees the same vocabulary.
+    expect(
+      screen.getByText('Connection lost — reconnecting…'),
+    ).toBeDefined();
+    // The host string is split across two text nodes ("Host: " + the
+    // IP), so use a function matcher instead of getByText. The trailing
+    // :8899 is stripped — we display just the IP, same as the StatusPage
+    // status bar. Use getAllByText with a custom matcher to find the
+    // leaf node and avoid the multiple-matches error from parent
+    // elements.
+    const hostNodes = screen.getAllByText((_content, node) => {
+      if (!node) return false;
+      const text = node.textContent ?? '';
+      // Leaf nodes only — exclude ancestors that also contain the IP
+      // through their children. Matches either "Host: 192.168.1.36" or
+      // the bare IP.
+      const hasIp = text.includes('192.168.1.36');
+      const isLeaf = Array.from(node.childNodes).every(
+        (c) => c.nodeType !== 1 || (c as Element).tagName === undefined,
+      );
+      return hasIp && (isLeaf || text.trim() === '192.168.1.36');
+    });
+    expect(hostNodes.length).toBeGreaterThan(0);
+
+    // None of the page's section headings should be rendered. We assert on
+    // the most distinctive ones (Battery Mode, Quick Actions, Charge
+    // Schedule) — a future control addition that accidentally leaks past
+    // the gate would trip one of these.
+    expect(screen.queryByRole('heading', { name: 'Quick Actions', exact: true })).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Battery Mode', exact: true })).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Charge Schedule', exact: true })).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Discharge Schedule', exact: true })).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Battery and Power Controls', exact: true })).toBeNull();
+
+    // The Retry button is there so the user can poke the backend instead
+    // of waiting for the poll loop's own back-off.
+    expect(screen.getByRole('button', { name: /Retry now/i })).toBeDefined();
+  });
+
+  it('shows the disconnected wording and hides controls when the loop has given up', () => {
+    useInverterStore.setState({
+      snapshot: null,
+      developerMode: false,
+      connectionState: 'disconnected',
+      connectedHost: '192.168.1.36:8899',
+    });
+    render(<ControlPage />);
+
+    // 'disconnected' is the initial state before any TCP attempt has
+    // succeeded and also the state the poll loop enters after
+    // sustained failures where it can't even open a socket. Either way,
+    // the page must not render controls.
+    expect(
+      screen.getByText('Disconnected — will retry automatically'),
+    ).toBeDefined();
+    expect(screen.queryByRole('heading', { name: 'Battery Mode', exact: true })).toBeNull();
+  });
+
+  it('renders the full controls once the connection is restored', async () => {
+    // Regression guard: the gate must be transparent in the steady state.
+    // If a future change accidentally persists the gate across the
+    // connected transition (e.g. by tracking snapshot-presence instead of
+    // connectionState), this test fails because no Battery Mode heading
+    // would render.
+    useInverterStore.setState({
+      snapshot: makeSnapshot(),
+      developerMode: false,
+      connectionState: 'connected',
+      connectedHost: '192.168.1.36:8899',
+    });
+    render(<ControlPage />);
+
+    // None of the disconnect-screen copy should be present.
+    expect(screen.queryByText(/Connection lost/i)).toBeNull();
+    expect(screen.queryByText(/Disconnected/i)).toBeNull();
+
+    // And the actual page content should render — we just check the
+    // distinctive headings, the same way the other ControlPage tests do.
+    expect(
+      await screen.findByRole('heading', { name: 'Quick Actions', exact: true }),
+    ).toBeDefined();
+    expect(
+      await screen.findByRole('heading', { name: 'Battery Mode', exact: true }),
+    ).toBeDefined();
+  });
+
+  it('POSTs to /api/reconnect when the Retry button is clicked', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    useInverterStore.setState({
+      snapshot: makeSnapshot(),
+      developerMode: false,
+      connectionState: 'reconnecting',
+      connectedHost: '192.168.1.36:8899',
+    });
+    render(<ControlPage />);
+
+    const retryButton = screen.getByRole('button', { name: /Retry now/i });
+    fireEvent.click(retryButton);
+
+    // The button drives `POST /api/reconnect` directly (same endpoint the
+    // StatusPage retry button uses) so a click from the ControlPage
+    // yields the same backend behaviour.
+    expect(fetchMock).toHaveBeenCalledWith('/api/reconnect', { method: 'POST' });
+
+    // The button shows "Reconnecting…" while the request is in flight.
+    expect(screen.getByText(/Reconnecting…/)).toBeDefined();
+  });
+
+  it('swallows network errors from the Retry click so the page does not crash', () => {
+    // A failed POST to /api/reconnect is not an error the page should
+    // surface — the poll loop's own back-off keeps retrying, so the
+    // user's manual retry is best-effort. A thrown promise here would
+    // surface as an unhandled rejection in production.
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    useInverterStore.setState({
+      snapshot: makeSnapshot(),
+      developerMode: false,
+      connectionState: 'reconnecting',
+      connectedHost: '192.168.1.36:8899',
+    });
+    render(<ControlPage />);
+
+    // The click must not throw and the gate must remain visible (so the
+    // user can keep retrying or wait for the backend's automatic back-off).
+    const retryButton = screen.getByRole('button', { name: /Retry now/i });
+    expect(() => fireEvent.click(retryButton)).not.toThrow();
+    expect(screen.getByText(/Connection lost/i)).toBeDefined();
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});

--- a/tests/pages/controlPageCosyDischargeSlots.test.tsx
+++ b/tests/pages/controlPageCosyDischargeSlots.test.tsx
@@ -234,7 +234,7 @@ describe('<ControlPage/> — Cosy mode discharge schedule visibility', () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     cleanup();
-    useInverterStore.setState({ snapshot: null });
+    useInverterStore.setState({ snapshot: null, connectionState: 'disconnected' });
   });
 
   async function timedDischargeSection() {
@@ -284,6 +284,7 @@ describe('<ControlPage/> — Cosy mode discharge schedule visibility', () => {
     useInverterStore.setState({
       snapshot: makeSnapshot({ cosy_enabled: true }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 
@@ -308,6 +309,7 @@ describe('<ControlPage/> — Cosy mode discharge schedule visibility', () => {
     useInverterStore.setState({
       snapshot: makeSnapshot({ cosy_enabled: false }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 
@@ -331,6 +333,7 @@ describe('<ControlPage/> — Cosy mode discharge schedule visibility', () => {
     useInverterStore.setState({
       snapshot: makeSnapshot({ cosy_enabled: false }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 

--- a/tests/pages/controlPageLoadLimiter.test.tsx
+++ b/tests/pages/controlPageLoadLimiter.test.tsx
@@ -196,7 +196,7 @@ describe('<ControlPage/> — Load Discharge Limiter status (issue #158)', () => 
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     cleanup();
-    useInverterStore.setState({ snapshot: null });
+    useInverterStore.setState({ snapshot: null, connectionState: 'disconnected' });
   });
 
   /** Resolve the Load Discharge Limiter wrapper so assertions can be
@@ -227,6 +227,7 @@ describe('<ControlPage/> — Load Discharge Limiter status (issue #158)', () => 
         home_power: 10000,
       }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 
@@ -256,6 +257,7 @@ describe('<ControlPage/> — Load Discharge Limiter status (issue #158)', () => 
         home_power: 5000, // below 7 kW threshold
       }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 
@@ -280,6 +282,7 @@ describe('<ControlPage/> — Load Discharge Limiter status (issue #158)', () => 
         home_power: 10000,
       }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 
@@ -301,6 +304,7 @@ describe('<ControlPage/> — Load Discharge Limiter status (issue #158)', () => 
         home_power: 2000,
       }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 
@@ -321,6 +325,7 @@ describe('<ControlPage/> — Load Discharge Limiter status (issue #158)', () => 
         home_power: 10000,
       }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 
@@ -340,6 +345,7 @@ describe('<ControlPage/> — Load Discharge Limiter status (issue #158)', () => 
         home_power: 0,
       }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 
@@ -361,6 +367,7 @@ describe('<ControlPage/> — Load Discharge Limiter status (issue #158)', () => 
         home_power: 2000,
       }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 
@@ -381,6 +388,7 @@ describe('<ControlPage/> — Load Discharge Limiter status (issue #158)', () => 
         home_power: 0,
       }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 

--- a/tests/pages/controlPageTimedDischargeGating.test.tsx
+++ b/tests/pages/controlPageTimedDischargeGating.test.tsx
@@ -194,7 +194,7 @@ describe('<ControlPage/> — Timed Discharge device gating', () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     cleanup();
-    useInverterStore.setState({ snapshot: null });
+    useInverterStore.setState({ snapshot: null, connectionState: 'disconnected' });
   });
 
   async function batteryModeSection() {
@@ -216,6 +216,7 @@ describe('<ControlPage/> — Timed Discharge device gating', () => {
       useInverterStore.setState({
         snapshot: makeSnapshot({ device_type_code: code }),
         developerMode: false,
+        connectionState: 'connected',
       });
       render(<ControlPage />);
 
@@ -244,6 +245,7 @@ describe('<ControlPage/> — Timed Discharge device gating', () => {
       useInverterStore.setState({
         snapshot: makeSnapshot({ device_type_code: code }),
         developerMode: false,
+        connectionState: 'connected',
       });
       render(<ControlPage />);
 
@@ -262,6 +264,7 @@ describe('<ControlPage/> — Timed Discharge device gating', () => {
       useInverterStore.setState({
         snapshot: makeSnapshot({ device_type_code: '2001', firmware_version: '318' }),
         developerMode: false,
+        connectionState: 'connected',
       });
       render(<ControlPage />);
 
@@ -278,6 +281,7 @@ describe('<ControlPage/> — Timed Discharge device gating', () => {
       useInverterStore.setState({
         snapshot: makeSnapshot({ device_type_code: '2001', firmware_version: fw }),
         developerMode: false,
+        connectionState: 'connected',
       });
       render(<ControlPage />);
 
@@ -288,7 +292,7 @@ describe('<ControlPage/> — Timed Discharge device gating', () => {
   });
 
   it('stays hidden before the first snapshot arrives', async () => {
-    useInverterStore.setState({ snapshot: null, developerMode: false });
+    useInverterStore.setState({ snapshot: null, developerMode: false, connectionState: 'connected' });
     render(<ControlPage />);
 
     await screen.findByRole('heading', { name: 'Battery Mode' });

--- a/tests/pages/controlPageTimedExportMode.test.tsx
+++ b/tests/pages/controlPageTimedExportMode.test.tsx
@@ -195,7 +195,7 @@ describe('<ControlPage/> — independent battery mechanisms', () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     cleanup();
-    useInverterStore.setState({ snapshot: null });
+    useInverterStore.setState({ snapshot: null, connectionState: 'disconnected' });
   });
 
   async function batteryModeSection() {
@@ -212,6 +212,7 @@ describe('<ControlPage/> — independent battery mechanisms', () => {
     useInverterStore.setState({
       snapshot: makeSnapshot({ device_type_code: '3001' }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 
@@ -223,7 +224,7 @@ describe('<ControlPage/> — independent battery mechanisms', () => {
   });
 
   it('toggles Timed Export through the split endpoint, not the old combined mode endpoint', async () => {
-    useInverterStore.setState({ snapshot: makeSnapshot({ enable_discharge: false }), developerMode: false });
+    useInverterStore.setState({ snapshot: makeSnapshot({ enable_discharge: false }), developerMode: false, connectionState: 'connected' });
     render(<ControlPage />);
 
     const section = await batteryModeSection();
@@ -234,7 +235,7 @@ describe('<ControlPage/> — independent battery mechanisms', () => {
   });
 
   it('toggles Timed Charge independently through HR96 endpoint', async () => {
-    useInverterStore.setState({ snapshot: makeSnapshot({ enable_charge: false }), developerMode: false });
+    useInverterStore.setState({ snapshot: makeSnapshot({ enable_charge: false }), developerMode: false, connectionState: 'connected' });
     render(<ControlPage />);
 
     const section = await batteryModeSection();
@@ -250,6 +251,7 @@ describe('<ControlPage/> — independent battery mechanisms', () => {
     useInverterStore.setState({
       snapshot: makeSnapshot({ device_type_code: '3001', battery_pause_mode: 0 }),
       developerMode: false,
+      connectionState: 'connected',
     });
     render(<ControlPage />);
 


### PR DESCRIPTION
When the GivEnergy dongle's TCP stack is fine but its Modbus processor is briefly slow, the poll loop used to tear the session down on the first post-connect warmup timeout, increment the dead-session back-off, and reconnect only to fail the warmup again — producing an unbroken chain of 5–30s reconnect cycles with no useful polls in between. The Control page also kept rendering all of its controls against a stale snapshot during a reconnect cycle, so users saw interactive sliders and Save buttons that POSTed to a backend that couldn't reach the dongle.

## Backend (`src-tauri/src/inverter/poll.rs`)

Drop the warmup kill-switch. Warmup failures now log a warning and fall through to the inner poll loop, matching GivTCP's `watch_plant()` model where TCP up means keep going. Warmup retries are reduced from 4 to 2 to match the steady-state poll's per-block retry budget, so a slow-but-healthy dongle that recovers mid-cycle is allowed to recover instead of being condemned after one multi-block read fails. A genuinely unresponsive session is still caught by `MAX_CONSECUTIVE_TIMEOUTS` (~36s of silence).

## Frontend (`src/pages/ControlPage.tsx`)

Add a connection-state gate at the top of the JSX. When `connectionState` is `'reconnecting'` or `'disconnected'`, the page renders a "Connection lost — reconnecting…" screen with the host and a Retry button, mirroring StatusPage / InverterPage. Controls reappear automatically once the next `Connection { state: Connected }` frame arrives.

## Tests

- New compile-time-pinned assertion (`warmup_matches_steady_state_poll_retries`) so a future tweak cannot re-introduce a stricter warmup.
- Updated the five existing ControlPage test fixtures to seed `connectionState: 'connected'` (the new gate makes this necessary).
- New `tests/pages/controlPageConnectionGate.test.tsx` with five cases covering reconnecting / disconnected / connected / Retry-click / network-error-swallowed.

## Verification

- `cargo clippy` clean
- `npm run lint` clean
- `npm run lint:md` clean
- `npm run build` clean
- `cargo test` — 904 / 904 pass
- `npm run test` (vitest) — 620 / 620 pass (was 615, +5 new)

CHANGELOG: two entries under `[Unreleased]`.