### PR TITLE
Break out standing charge on the History cost graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **See your import cost broken down on the History Cost graph.** When you
+  have a Standing Charge configured, the Cost tab's Import Cost line is now
+  joined by two more lines: Energy Cost (what you pay for the units you
+  actually import, at your time-of-use rate) and a dashed Standing Charge
+  line (the fixed daily fee). The gap between Import Cost and Energy Cost is
+  the standing charge, so you can see at a glance how much of your bill is
+  the daily charge versus energy used. With no Standing Charge set the chart
+  is unchanged. All three lines can be toggled from the legend and are
+  included in the CSV export.
+
 ## [0.51.1] - 2026-07-01
 
 ### Changed

--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -24,6 +24,23 @@ pub struct TimePoint {
     pub v: f64,
 }
 
+/// One display bucket of a cost/income series, split into its per-kWh energy
+/// component and its fixed daily standing-charge component (both cumulative £
+/// over the query window). The two always sum to the total value
+/// [`HistoryDb::query_cost_series`] plots for the same bucket, so the History
+/// cost chart can draw energy versus standing charge without ever subtracting
+/// one series from another (which would drift with float error and mismatched
+/// bucket timestamps).
+#[derive(Debug, Clone, Copy)]
+pub struct CostComponentPoint {
+    /// Unix timestamp in milliseconds.
+    pub t: i64,
+    /// Cumulative per-kWh (time-of-use) cost at this bucket, in £.
+    pub energy_gbp: f64,
+    /// Cumulative standing-charge (fixed daily fee) at this bucket, in £.
+    pub standing_gbp: f64,
+}
+
 // ---------------------------------------------------------------------------
 // Allowed field whitelist (prevents SQL injection)
 // ---------------------------------------------------------------------------
@@ -129,9 +146,25 @@ fn same_utc_day(a_ms: i64, b_ms: i64) -> bool {
 pub const IMPORT_COST_FIELD: &str = "_import_cost";
 pub const EXPORT_INCOME_FIELD: &str = "_export_income";
 
+/// Import-cost breakdown fields. `_import_cost` is the sum of the two:
+/// `_import_energy_cost` is the per-kWh (time-of-use) component, and
+/// `_import_standing_charge` is the fixed daily standing-charge component
+/// (the once-per-local-day step). Splitting them lets the History cost chart
+/// show what the user pays for energy versus the flat daily fee. Both are
+/// served from the same single [`HistoryDb::query_cost_breakdown`] walk so
+/// `energy + standing` equals `_import_cost` exactly, with no float drift.
+pub const IMPORT_ENERGY_COST_FIELD: &str = "_import_energy_cost";
+pub const IMPORT_STANDING_CHARGE_FIELD: &str = "_import_standing_charge";
+
 /// True for the server-derived cost/income fields.
 pub fn is_cost_field(field: &str) -> bool {
-    field == IMPORT_COST_FIELD || field == EXPORT_INCOME_FIELD
+    matches!(
+        field,
+        IMPORT_COST_FIELD
+            | EXPORT_INCOME_FIELD
+            | IMPORT_ENERGY_COST_FIELD
+            | IMPORT_STANDING_CHARGE_FIELD
+    )
 }
 
 /// Field names for the server-derived DIRECTIONAL power series.
@@ -1166,8 +1199,45 @@ impl HistoryDb {
         Ok(result)
     }
 
-    /// Compute a cumulative cost/income series (£) for a daily energy counter
-    /// over the query window, priced with a time-of-use `tariff`.
+    /// Cumulative cost/income series (£) for a daily energy counter over the
+    /// query window: the per-kWh component plus the standing charge, summed.
+    ///
+    /// This is the total the History "Cost" tab plots as `_import_cost` /
+    /// `_export_income`, and the total the `/api/report` summary sums. It's a
+    /// thin wrapper that adds the two components returned by
+    /// [`HistoryDb::query_cost_breakdown`]; see that method for the full
+    /// pricing and standing-charge-step semantics.
+    pub fn query_cost_series(
+        &self,
+        window: &HistoryWindow,
+        bucket_secs: i64,
+        counter_field: &str,
+        tariff: &crate::settings::TariffConfig,
+        flat_fallback: f64,
+        standing_charge_p_per_day: f64,
+    ) -> Result<Vec<TimePoint>, String> {
+        Ok(self
+            .query_cost_breakdown(
+                window,
+                bucket_secs,
+                counter_field,
+                tariff,
+                flat_fallback,
+                standing_charge_p_per_day,
+            )?
+            .into_iter()
+            .map(|c| TimePoint {
+                t: c.t,
+                v: c.energy_gbp + c.standing_gbp,
+            })
+            .collect())
+    }
+
+    /// Compute a cumulative cost/income **breakdown** series for a daily energy
+    /// counter over the query window, priced with a time-of-use `tariff`. Each
+    /// point carries the per-kWh energy component and the standing-charge
+    /// component separately (see [`CostComponentPoint`]); [`Self::query_cost_series`]
+    /// sums them for callers that only want the total.
     ///
     /// Why this can't reuse the aggregated (`MAX`-bucket) path: a time-of-use
     /// rate must be applied to each energy increment at the moment it actually
@@ -1199,9 +1269,9 @@ impl HistoryDb {
     /// (£) at each local midnight that falls within the query window. So a
     /// 7-day range with a 54.86p/day Standing Charge shows 7 visible steps
     /// in the cost graph (one per day), each of size £0.5486, layered on
-    /// top of the per-kWh cost component. A value of 0 leaves the series
-    /// unchanged. See issue #131.
-    pub fn query_cost_series(
+    /// top of the per-kWh cost component. A value of 0 leaves the standing
+    /// component at zero. See issue #131.
+    pub fn query_cost_breakdown(
         &self,
         window: &HistoryWindow,
         bucket_secs: i64,
@@ -1209,7 +1279,7 @@ impl HistoryDb {
         tariff: &crate::settings::TariffConfig,
         flat_fallback: f64,
         standing_charge_p_per_day: f64,
-    ) -> Result<Vec<TimePoint>, String> {
+    ) -> Result<Vec<CostComponentPoint>, String> {
         // Guard the SQL identifier - only the two daily counters drive cost.
         if counter_field != "today_import_kwh" && counter_field != "today_export_kwh" {
             return Err(format!("Unsupported cost counter field: {counter_field}"));
@@ -1259,10 +1329,13 @@ impl HistoryDb {
             .map_err(|e| format!("Cost query failed: {e}"))?
             .filter_map(SqlResult::ok);
 
-        // bucket_start_ms -> cumulative cost at that bucket's last reading.
-        // BTreeMap keeps display points sorted; the cumulative series is
-        // monotonic non-decreasing so the last write per bucket is its max.
-        let mut buckets: std::collections::BTreeMap<i64, f64> = std::collections::BTreeMap::new();
+        // bucket_start_ms -> (per-kWh energy £, standing-charge £) at that
+        // bucket's last reading. BTreeMap keeps display points sorted; both
+        // components are monotonic non-decreasing so the last write per
+        // bucket is its max. Kept split (rather than pre-summed) so the
+        // breakdown fields and the total both come from this one walk.
+        let mut buckets: std::collections::BTreeMap<i64, (f64, f64)> =
+            std::collections::BTreeMap::new();
         let mut acc = 0.0_f64;
         // `baseline` is the counter value of the last *counted* reading on the
         // current day; `last_ts` is the previous reading's time (for the
@@ -1358,7 +1431,7 @@ impl HistoryDb {
             // per-day amount at every local midnight within the window.
             let standing_charge_total =
                 standing_charge_days_credited as f64 * standing_charge_gbp_per_day;
-            buckets.insert(bucket_ms, acc + standing_charge_total);
+            buckets.insert(bucket_ms, (acc, standing_charge_total));
             last_ts = Some(ts);
         }
 
@@ -1385,7 +1458,7 @@ impl HistoryDb {
             // (avoid clobbering an existing bucket from the readings walk).
             buckets
                 .entry(end_bucket_ms)
-                .or_insert(acc + standing_charge_total);
+                .or_insert((acc, standing_charge_total));
         }
 
         // Always emit at least the window-open bucket with the standing
@@ -1405,12 +1478,16 @@ impl HistoryDb {
             // `standing_charge_days_credited` because the trailing logic
             // didn't run (no readings means no `last_ts` to anchor it).
             let sc = total_days_in_window as f64 * standing_charge_gbp_per_day;
-            buckets.insert(open_bucket_ms, sc);
+            buckets.insert(open_bucket_ms, (0.0, sc));
         }
 
         Ok(buckets
             .into_iter()
-            .map(|(t, v)| TimePoint { t, v })
+            .map(|(t, (energy_gbp, standing_gbp))| CostComponentPoint {
+                t,
+                energy_gbp,
+                standing_gbp,
+            })
             .collect())
     }
 
@@ -1910,6 +1987,22 @@ mod tests {
         assert!(!is_directional_field("_import_cost"));
         assert!(!is_directional_field("_charge_power; DROP TABLE readings"));
         assert!(!is_directional_field(""));
+    }
+
+    /// `is_cost_field` is the single chokepoint that keeps the four derived
+    /// cost fields out of `query_history`'s column-whitelist SQL path and
+    /// routes them to the cost engine instead. Pin all four positives (incl.
+    /// the two breakdown fields) and a few negatives.
+    #[test]
+    fn is_cost_field_helper() {
+        assert!(is_cost_field(IMPORT_COST_FIELD));
+        assert!(is_cost_field(EXPORT_INCOME_FIELD));
+        assert!(is_cost_field(IMPORT_ENERGY_COST_FIELD));
+        assert!(is_cost_field(IMPORT_STANDING_CHARGE_FIELD));
+        assert!(!is_cost_field("today_import_kwh"));
+        assert!(!is_cost_field(CHARGE_POWER_FIELD));
+        assert!(!is_cost_field("_import_cost; DROP TABLE readings"));
+        assert!(!is_cost_field(""));
     }
 
     #[test]
@@ -3880,8 +3973,45 @@ mod tests {
         }
     }
 
+    /// Insert one local day of a daily-resetting IMPORT counter (mirror of
+    /// [`insert_export_day`] on the import side). Used by the cost-breakdown
+    /// tests, where the standing charge only applies to the import direction.
+    fn insert_import_day(
+        db: &HistoryDb,
+        day_offset: i64,
+        daily_kwh: f32,
+        rise_start_min: i64,
+        rise_end_min: i64,
+    ) {
+        let midnight = local_midnight_secs(day_offset);
+        for step in 0..48i64 {
+            let ts = midnight + step * 1800;
+            let min_of_day = step * 30;
+            let frac = if min_of_day <= rise_start_min {
+                0.0
+            } else if min_of_day >= rise_end_min {
+                1.0
+            } else {
+                (min_of_day - rise_start_min) as f64 / (rise_end_min - rise_start_min) as f64
+            };
+            db.insert_reading(&make_snapshot_with_kwh(
+                ts,
+                (daily_kwh as f64 * frac) as f32,
+                0.0,
+            ));
+        }
+    }
+
     fn series_total(series: &[TimePoint]) -> f64 {
         series.last().map(|p| p.v).unwrap_or(0.0)
+    }
+
+    /// Cumulative value of a breakdown component at its last bucket.
+    fn breakdown_energy_total(series: &[CostComponentPoint]) -> f64 {
+        series.last().map(|p| p.energy_gbp).unwrap_or(0.0)
+    }
+    fn breakdown_standing_total(series: &[CostComponentPoint]) -> f64 {
+        series.last().map(|p| p.standing_gbp).unwrap_or(0.0)
     }
 
     /// A `HistoryWindow` pinned to explicit `(start, end)` UTC-second bounds —
@@ -4570,6 +4700,106 @@ mod tests {
         assert!(
             post_midnight - pre_midnight >= 0.5486 - 1e-6,
             "the cost graph must step UP at the local midnight by at least one day's Standing Charge (pre={pre_midnight}, post={post_midnight})"
+        );
+    }
+
+    // -- Import-cost breakdown (energy vs standing charge) -----------------
+
+    #[test]
+    fn cost_breakdown_energy_plus_standing_equals_total_per_bucket() {
+        // The two breakdown components must sum, bucket-for-bucket, to the
+        // total `query_cost_series` plots — the invariant the History chart
+        // relies on to draw energy and standing charge as separate lines
+        // whose implied sum is the (red) total line.
+        let db = test_db();
+        for d in 0..3 {
+            insert_import_day(&db, d, 10.0, 6 * 60, 10 * 60);
+        }
+        let start = local_midnight_secs(0);
+        let end = local_midnight_secs(4);
+        let flat = crate::settings::TariffConfig::flat(0.25);
+        let w = window(start, end);
+        let breakdown = db
+            .query_cost_breakdown(&w, 3600, "today_import_kwh", &flat, 0.25, 54.86)
+            .unwrap();
+        let total = db
+            .query_cost_series(&w, 3600, "today_import_kwh", &flat, 0.25, 54.86)
+            .unwrap();
+        assert_eq!(
+            breakdown.len(),
+            total.len(),
+            "breakdown and total series must share the same buckets"
+        );
+        for (c, t) in breakdown.iter().zip(total.iter()) {
+            assert_eq!(c.t, t.t, "bucket timestamps must line up");
+            assert!(
+                (c.energy_gbp + c.standing_gbp - t.v).abs() < 1e-9,
+                "energy ({}) + standing ({}) must equal total ({}) at t={}",
+                c.energy_gbp,
+                c.standing_gbp,
+                t.v,
+                t.t
+            );
+        }
+    }
+
+    #[test]
+    fn cost_breakdown_zero_standing_charge_has_zero_standing_component() {
+        // With no Standing Charge configured, the standing component must be
+        // flat zero and the energy component must equal the whole cost — the
+        // case where the History chart keeps the breakdown lines hidden.
+        let db = test_db();
+        insert_import_day(&db, 0, 12.0, 6 * 60, 10 * 60);
+        let start = local_midnight_secs(0);
+        let end = local_midnight_secs(1);
+        let flat = crate::settings::TariffConfig::flat(0.25);
+        let breakdown = db
+            .query_cost_breakdown(&window(start, end), 3600, "today_import_kwh", &flat, 0.25, 0.0)
+            .unwrap();
+        assert!(
+            breakdown.iter().all(|c| c.standing_gbp == 0.0),
+            "standing component must be zero when no Standing Charge is set"
+        );
+        // 12 kWh × £0.25 = £3.00, all in the energy component.
+        assert!(
+            (breakdown_energy_total(&breakdown) - 3.0).abs() < 1e-6,
+            "energy component should carry the full £3.00 (got {})",
+            breakdown_energy_total(&breakdown)
+        );
+        assert!(
+            breakdown_standing_total(&breakdown).abs() < 1e-9,
+            "standing total should be £0.00 (got {})",
+            breakdown_standing_total(&breakdown)
+        );
+    }
+
+    #[test]
+    fn cost_breakdown_splits_energy_from_standing_charge() {
+        // With a Standing Charge configured, the energy component must be the
+        // pure per-kWh cost (independent of the standing charge) and the
+        // standing component must be exactly one debit per local day touched.
+        let db = test_db();
+        for d in 0..3 {
+            insert_import_day(&db, d, 10.0, 6 * 60, 10 * 60);
+        }
+        // 4-day window: 00:00 day-0 → 00:00 day-4 (touches 4 calendar days).
+        let start = local_midnight_secs(0);
+        let end = local_midnight_secs(4);
+        let flat = crate::settings::TariffConfig::flat(0.25);
+        let breakdown = db
+            .query_cost_breakdown(&window(start, end), 3600, "today_import_kwh", &flat, 0.25, 54.86)
+            .unwrap();
+        // Energy: 3 days × 10 kWh × £0.25 = £7.50 (NOT inflated by the SC).
+        assert!(
+            (breakdown_energy_total(&breakdown) - 7.50).abs() < 1e-3,
+            "energy component should be the pure per-kWh cost £7.50 (got {})",
+            breakdown_energy_total(&breakdown)
+        );
+        // Standing: 4 days × £0.5486 = £2.1944.
+        assert!(
+            (breakdown_standing_total(&breakdown) - 4.0 * 0.5486).abs() < 1e-3,
+            "standing component should be 4 × £0.5486 (got {})",
+            breakdown_standing_total(&breakdown)
         );
     }
 }

--- a/src-tauri/src/server/api.rs
+++ b/src-tauri/src/server/api.rs
@@ -2543,6 +2543,16 @@ pub async fn get_history(
     let want_import_cost = fields
         .iter()
         .any(|f| f == crate::history::IMPORT_COST_FIELD);
+    // Import-cost breakdown: the per-kWh energy component and the fixed daily
+    // standing-charge component, split out of the same total so the History
+    // chart can show them as separate lines.
+    let want_import_energy = fields
+        .iter()
+        .any(|f| f == crate::history::IMPORT_ENERGY_COST_FIELD);
+    let want_import_standing = fields
+        .iter()
+        .any(|f| f == crate::history::IMPORT_STANDING_CHARGE_FIELD);
+    let want_any_import_cost = want_import_cost || want_import_energy || want_import_standing;
     let want_export_income = fields
         .iter()
         .any(|f| f == crate::history::EXPORT_INCOME_FIELD);
@@ -2556,7 +2566,7 @@ pub async fn get_history(
     // to a flat single-slot config built from the legacy scalar rate.
     // Issue #131: also carry the import-side Standing Charge (pence/day)
     // so the cost series includes the daily fixed component.
-    let cost_cfgs = if want_import_cost || want_export_income {
+    let cost_cfgs = if want_any_import_cost || want_export_income {
         let s = crate::settings::Settings::load();
         let import_cfg = s
             .import_tariff_config
@@ -2614,24 +2624,61 @@ pub async fn get_history(
                         import_standing_charge_p_per_day,
                     )) = &cost_cfgs
                     {
-                        if want_import_cost {
-                            let series = db.query_cost_series(
+                        if want_any_import_cost {
+                            // One walk yields both components; the total, the
+                            // per-kWh energy series and the standing-charge
+                            // series are all cut from it so `energy + standing`
+                            // matches the total exactly. Issue #131: the
+                            // import direction carries the daily standing
+                            // charge; export doesn't (UK SEG has no standing
+                            // fee on exports), so it's served separately below.
+                            let breakdown = db.query_cost_breakdown(
                                 &window,
                                 bucket_secs,
                                 "today_import_kwh",
                                 import_cfg,
                                 *flat_import,
-                                // Issue #131: include the daily standing
-                                // charge on the import cost series. Export
-                                // direction doesn't carry one (UK SEG has
-                                // no standing fee on exports), so it stays
-                                // at 0 on the export side.
                                 *import_standing_charge_p_per_day,
                             )?;
-                            data.insert(
-                                crate::history::IMPORT_COST_FIELD.to_string(),
-                                serde_json::to_value(&series).unwrap_or(Value::Null),
-                            );
+                            if want_import_cost {
+                                let series: Vec<crate::history::TimePoint> = breakdown
+                                    .iter()
+                                    .map(|c| crate::history::TimePoint {
+                                        t: c.t,
+                                        v: c.energy_gbp + c.standing_gbp,
+                                    })
+                                    .collect();
+                                data.insert(
+                                    crate::history::IMPORT_COST_FIELD.to_string(),
+                                    serde_json::to_value(&series).unwrap_or(Value::Null),
+                                );
+                            }
+                            if want_import_energy {
+                                let series: Vec<crate::history::TimePoint> = breakdown
+                                    .iter()
+                                    .map(|c| crate::history::TimePoint {
+                                        t: c.t,
+                                        v: c.energy_gbp,
+                                    })
+                                    .collect();
+                                data.insert(
+                                    crate::history::IMPORT_ENERGY_COST_FIELD.to_string(),
+                                    serde_json::to_value(&series).unwrap_or(Value::Null),
+                                );
+                            }
+                            if want_import_standing {
+                                let series: Vec<crate::history::TimePoint> = breakdown
+                                    .iter()
+                                    .map(|c| crate::history::TimePoint {
+                                        t: c.t,
+                                        v: c.standing_gbp,
+                                    })
+                                    .collect();
+                                data.insert(
+                                    crate::history::IMPORT_STANDING_CHARGE_FIELD.to_string(),
+                                    serde_json::to_value(&series).unwrap_or(Value::Null),
+                                );
+                            }
                         }
                         if want_export_income {
                             let series = db.query_cost_series(

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -8,7 +8,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
-import { fetchHistory, isTauri } from '../lib/api';
+import { apiGet, fetchHistory, isTauri } from '../lib/api';
 import {
   getHistoryChartGridProps,
   HISTORY_RANGES,
@@ -31,7 +31,7 @@ import { getSeriesOpacity, removeSpikes } from '../lib/chartSeries';
 import { SeriesLegend } from '../components/SeriesLegend';
 import { useInverterStore } from '../store/useInverterStore';
 import type { SeriesLegendItem } from '../components/SeriesLegend';
-import type { HistoryRange } from '../lib/types';
+import type { HistoryRange, PollSettings } from '../lib/types';
 import { computeTempDifferential, computeBatteryExternalDifferential } from '../lib/temperatureChart';
 import { computeTightDomain } from '../lib/chartDomain';
 import { openExternal } from '../lib/openExternal';
@@ -50,7 +50,18 @@ type MetricTab = 'battery' | 'solar' | 'grid' | 'home' | 'cost' | 'temperature';
 interface ChartDef {
   key: string;
   title: string;
-  fields: { field: string; color: string; label?: string }[];
+  fields: {
+    field: string;
+    color: string;
+    label?: string;
+    /**
+     * Optional dashed stroke (Recharts `strokeDasharray`, e.g. "4 3").
+     * Undefined = solid line, matching every existing series. Used to set
+     * the Standing Charge line apart from the solid cost lines it sits
+     * alongside on the Cost tab.
+     */
+    strokeDasharray?: string;
+  }[];
   unit: string;
   yDomain?: [number, number];
   /**
@@ -83,7 +94,7 @@ const TABS: { key: MetricTab; label: string }[] = [
   { key: 'cost', label: 'Cost' },
 ];
 
-function getCharts(tab: MetricTab): ChartDef[] {
+function getCharts(tab: MetricTab, hasStandingCharge: boolean): ChartDef[] {
   switch (tab) {
     case 'battery':
       return [
@@ -206,23 +217,42 @@ function getCharts(tab: MetricTab): ChartDef[] {
           preprocess: (merged) => computeBatteryExternalDifferential(merged),
         },
       ];
-    case 'cost':
+    case 'cost': {
+      // `_import_cost` / `_export_income` are server-derived cumulative
+      // series: the backend integrates the today_*_kwh counters against the
+      // configured tariff at native reading resolution, so the totals are
+      // correct for time-of-use rates and consistent across every range's
+      // bucket width. The frontend just plots them.
+      const fields: ChartDef['fields'] = [
+        { field: '_import_cost', color: '#EF4444', label: 'Import Cost' },
+      ];
+      // When a Standing Charge is configured, break the import cost into its
+      // per-kWh energy component and the fixed daily standing charge, so the
+      // user can see the difference (the gap between Import Cost and Energy
+      // Cost is the standing charge). With no standing charge there's nothing
+      // to differentiate: Energy Cost would just duplicate Import Cost and
+      // Standing Charge would sit flat at £0, so we leave the chart as-is.
+      if (hasStandingCharge) {
+        fields.push(
+          { field: '_import_energy_cost', color: '#F59E0B', label: 'Energy Cost' },
+          {
+            field: '_import_standing_charge',
+            color: '#A78BFA',
+            label: 'Standing Charge',
+            strokeDasharray: '4 3',
+          },
+        );
+      }
+      fields.push({ field: '_export_income', color: '#22C55E', label: 'Export Income' });
       return [
         {
-          // `_import_cost` / `_export_income` are server-derived cumulative
-          // series: the backend integrates the today_*_kwh counters against the
-          // configured tariff at native reading resolution, so the totals are
-          // correct for time-of-use rates and consistent across every range's
-          // bucket width. The frontend just plots them.
           key: 'cost-combined',
           title: 'Import Cost & Export Income',
           unit: '£',
-          fields: [
-            { field: '_import_cost', color: '#EF4444', label: 'Import Cost' },
-            { field: '_export_income', color: '#22C55E', label: 'Export Income' },
-          ],
+          fields,
         },
       ];
+    }
   }
 }
 
@@ -433,6 +463,7 @@ function ChartCard({ chart, data, range, domain, ticks, gridLineWeight }: {
               type="monotone"
               dataKey={seriesNames[i]}
               stroke={f.color}
+              strokeDasharray={f.strokeDasharray}
               fill={`url(#grad-${chart.key}-${i})`}
               opacity={getSeriesOpacity(mutedSeries[seriesNames[i]] ?? false)}
               strokeWidth={2}
@@ -582,7 +613,25 @@ export default function HistoryPage() {
   const [offset, setOffset] = useState(0);
   const lastDateRef = useRef(getHistoryPickerValue(range, offset));
   const [data, setData] = useState<Record<string, TimePoint[]>>({});
-  
+  // Whether an import Standing Charge is configured. Drives the Cost tab's
+  // import-cost breakdown lines: with no standing charge there's nothing to
+  // break out, so the chart stays as Import Cost + Export Income.
+  const [hasStandingCharge, setHasStandingCharge] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiGet<{ ok: boolean; data: PollSettings }>('/api/settings')
+      .then((res) => {
+        if (!cancelled) {
+          setHasStandingCharge((res?.data?.import_standing_charge_p_per_day ?? 0) > 0);
+        }
+      })
+      .catch(() => {
+        // Settings unavailable: leave the breakdown hidden (unchanged chart).
+      });
+    return () => { cancelled = true; };
+  }, []);
+
   const now = useNow();
   const rolling = isRollingHistoryRange(range);
   const refreshKey = shouldRefreshHistoryRange(range, offset) ? now : 0;
@@ -593,7 +642,7 @@ export default function HistoryPage() {
 
   useEffect(() => {
     let cancelled = false;
-    const charts = getCharts(tab);
+    const charts = getCharts(tab, hasStandingCharge);
     const allFields = [
       ...new Set([
         ...charts.flatMap((c) => c.fields.map((f) => f.field)),
@@ -618,7 +667,7 @@ export default function HistoryPage() {
         }
       })
     return () => { cancelled = true; };
-  }, [tab, range, offset, refreshKey, rolling]);
+  }, [tab, range, offset, refreshKey, rolling, hasStandingCharge]);
 
   const handleTabChange = (t: MetricTab) => {
     setTab(t);
@@ -630,7 +679,7 @@ export default function HistoryPage() {
     setOffset(0);
   };
 
-  const charts = getCharts(tab);
+  const charts = getCharts(tab, hasStandingCharge);
   const hasData = Object.values(data).some((pts) => pts.length > 0);
   const [csvToast, setCsvToast] = useState<string | null>(null);
 

--- a/tests/pages/historyPageCostBreakdown.test.tsx
+++ b/tests/pages/historyPageCostBreakdown.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks - the Cost tab breaks the import cost into its per-kWh energy
+// component and the fixed daily standing charge, but ONLY when a standing
+// charge is configured. HistoryPage learns that from GET /api/settings, so
+// these tests drive `import_standing_charge_p_per_day` via the apiGet mock
+// and assert on the fields HistoryPage then requests from fetchHistory.
+// ---------------------------------------------------------------------------
+
+type FetchHistoryCall = { range: string; fields: string[]; offset: number };
+
+const fetchHistoryCalls: FetchHistoryCall[] = [];
+const fetchHistoryMock = vi.fn(async (...args: unknown[]) => {
+  const [range, fields, offset] = args as [string, string[], number];
+  fetchHistoryCalls.push({ range, fields, offset });
+  return {};
+});
+
+// Standing charge served by the mocked /api/settings; each test sets it.
+let standingChargePPerDay = 0;
+const apiGetMock = vi.fn(async (path: string) => {
+  if (path === '/api/settings') {
+    return { ok: true, data: { import_standing_charge_p_per_day: standingChargePPerDay } };
+  }
+  return { ok: true, data: {} };
+});
+
+vi.mock('../../src/lib/api', () => ({
+  apiGet: (...args: unknown[]) => apiGetMock(...(args as [string])),
+  fetchHistory: (...args: unknown[]) => fetchHistoryMock(...args),
+  getApiBase: () => 'http://localhost:7337',
+  getServerPort: () => 7337,
+  isTauri: false,
+}));
+
+// recharts' ResponsiveContainer uses ResizeObserver, which jsdom doesn't
+// provide. Install a no-op stub so the chart can mount without throwing.
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// Imported after the vi.mock() calls above.
+import HistoryPage from '../../src/pages/HistoryPage';
+import { useInverterStore } from '../../src/store/useInverterStore';
+
+async function clickTab(label: string) {
+  const btn = await screen.findByRole('button', { name: label, exact: true });
+  fireEvent.click(btn);
+}
+
+const IMPORT_COST = '_import_cost';
+const ENERGY_COST = '_import_energy_cost';
+const STANDING_CHARGE = '_import_standing_charge';
+const EXPORT_INCOME = '_export_income';
+
+describe('<HistoryPage/> - Cost tab import breakdown', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchHistoryCalls.length = 0;
+    fetchHistoryMock.mockClear();
+    apiGetMock.mockClear();
+    standingChargePPerDay = 0;
+    useInverterStore.setState({ snapshot: null, chartRange: '24h' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it('requests the energy + standing-charge breakdown when a standing charge is set', async () => {
+    standingChargePPerDay = 54.86;
+    render(<HistoryPage />);
+    await clickTab('Cost');
+    await waitFor(() => {
+      const fieldsUsed = new Set(fetchHistoryCalls.flatMap((c) => c.fields));
+      expect(fieldsUsed.has(ENERGY_COST)).toBe(true);
+    });
+    const fieldsUsed = new Set(fetchHistoryCalls.flatMap((c) => c.fields));
+    // All four import-cost lines plus export income are requested.
+    expect(fieldsUsed.has(IMPORT_COST)).toBe(true);
+    expect(fieldsUsed.has(ENERGY_COST)).toBe(true);
+    expect(fieldsUsed.has(STANDING_CHARGE)).toBe(true);
+    expect(fieldsUsed.has(EXPORT_INCOME)).toBe(true);
+  });
+
+  it('omits the breakdown fields when no standing charge is configured', async () => {
+    standingChargePPerDay = 0;
+    render(<HistoryPage />);
+    await clickTab('Cost');
+    // Wait until the Cost tab has fired its fetch (the total is always requested).
+    await waitFor(() => {
+      const fieldsUsed = new Set(fetchHistoryCalls.flatMap((c) => c.fields));
+      expect(fieldsUsed.has(IMPORT_COST)).toBe(true);
+    });
+    const fieldsUsed = new Set(fetchHistoryCalls.flatMap((c) => c.fields));
+    // Unchanged chart: only total import cost + export income, no breakdown.
+    expect(fieldsUsed.has(EXPORT_INCOME)).toBe(true);
+    expect(fieldsUsed.has(ENERGY_COST)).toBe(false);
+    expect(fieldsUsed.has(STANDING_CHARGE)).toBe(false);
+  });
+});


### PR DESCRIPTION
The Import Cost line on the History Cost tab bundled the per-kWh energy cost together with the fixed daily standing charge, so there was no way to tell how much of the bill was the standing charge. This breaks it out.

When you have a standing charge configured, the chart draws two extra lines alongside Import Cost and Export Income: Energy Cost (just the units you import, priced at your time-of-use rate) and a dashed violet Standing Charge line (the flat daily fee). The gap between Import Cost and Energy Cost is the standing charge. If you don't have a standing charge set there's nothing to break out, so the chart looks exactly as it did before.

The cost engine already worked out both parts and added them together, so I split query_cost_series into a query_cost_breakdown that keeps the two components separate per bucket; query_cost_series now just sums them, which leaves /api/report and the export-income series untouched. The two new derived fields (_import_energy_cost, _import_standing_charge) come from a single DB walk, so energy plus standing always equals the total exactly, with no float drift. All three import lines toggle from the legend and are included in the CSV export.


<img width="1792" height="536" alt="image" src="https://github.com/user-attachments/assets/eb9c0076-c3e9-41a5-86d0-2baacd5eafa9" />
