### PR TITLE
ci: stop uploading NSIS .exe installer to releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -351,7 +351,7 @@ jobs:
           for path in bundle_dir.rglob("*"):
               if not path.is_file():
                   continue
-              if path.suffix.lower() not in {".dmg", ".deb", ".rpm", ".msi", ".msix", ".exe"}:
+              if path.suffix.lower() not in {".dmg", ".deb", ".rpm", ".msi", ".msix"}:
                   continue
               dest = out_dir / friendly_name(path)
               if " " in dest.name:


### PR DESCRIPTION
## Summary
- Removes `.exe` from the release asset allow-list in the build workflow
- The NSIS installer still builds during `cargo tauri build`, but is no longer collected into `release-assets/` and won't appear on the release download page
- The release body's download guide already only listed MSI/MSIX for Windows — this just stops uploading the orphan asset