### PR TITLE
Rename LXC update command to `update`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -431,7 +431,7 @@ The helper prints the container ID and dashboard URL when installation
 finishes. To update later, run the installed update command through Proxmox:
 
 ```bash
-pct exec <container-id> -- home-energy-manager-update
+pct exec <container-id> -- update
 ```
 
 Updates stop the service, save a pre-update copy of the persistent data under

--- a/scripts/proxmox/create-lxc.sh
+++ b/scripts/proxmox/create-lxc.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 
 REPO="psylsph/home-energy-manager"
 SCRIPT_REF="${HEM_SCRIPT_REF:-master}"
-INSTALLER_SHA256="f7597292d4b80fa21a4902a9e3dccf4b915ac86c601413765df98beee25cafd5"
+INSTALLER_SHA256="d1f8de768552590faed009a8beb511ca29fb34b99c3317d64b4e28c9e4afa78e"
 CTID="${HEM_CTID:-}"
 HOSTNAME="${HEM_HOSTNAME:-home-energy-manager}"
 CORES="${HEM_CORES:-1}"
@@ -162,4 +162,4 @@ IP_ADDRESS="$(pct exec "$CTID" -- hostname -I 2>/dev/null | awk '{ print $1 }')"
 printf '\nHome Energy Manager LXC created successfully.\n'
 printf '  Container ID: %s\n' "$CTID"
 printf '  Dashboard:    http://%s:%s\n' "${IP_ADDRESS:-<container-ip>}" "$PORT"
-printf '  Update:       pct exec %s -- home-energy-manager-update\n' "$CTID"
+printf '  Update:       pct exec %s -- update\n' "$CTID"

--- a/scripts/proxmox/install.sh
+++ b/scripts/proxmox/install.sh
@@ -7,7 +7,9 @@ DESTDIR="${HEM_ROOT:-}"
 DATA_DIR="/var/lib/givenergy-local"
 SERVICE_NAME="home-energy-manager.service"
 SERVICE_PATH="/etc/systemd/system/${SERVICE_NAME}"
-UPDATER_PATH="/usr/local/sbin/home-energy-manager-update"
+UPDATER_PATH="/usr/local/bin/update"
+# Legacy path from <v0.72.0; removed on upgrade so stale copies don't linger.
+OLD_UPDATER_PATH="/usr/local/sbin/home-energy-manager-update"
 PORT_CONFIG_PATH="/etc/default/home-energy-manager"
 
 fail() {
@@ -52,6 +54,10 @@ curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
 TAG="$(jq -er '.tag_name' "$RELEASE_JSON")" || fail "latest GitHub release has no tag"
 [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "unexpected release tag: $TAG"
 INSTALLED_VERSION="$(dpkg-query -W -f='${Version}' home-energy-manager 2>/dev/null || true)"
+# Remove the legacy <v0.72.0 updater path if it exists from a prior install.
+if [ -e "$(root_path "$OLD_UPDATER_PATH")" ]; then
+  rm -f "$(root_path "$OLD_UPDATER_PATH")"
+fi
 if [ "$INSTALLED_VERSION" = "${TAG#v}" ]; then
   systemctl enable --now "$SERVICE_NAME"
   printf 'Home Energy Manager %s is already installed and running.\n' "$TAG"
@@ -141,6 +147,7 @@ cleanup_failed_install() {
   systemctl disable --now "$SERVICE_NAME" || true
   rm -f "$(root_path "$SERVICE_PATH")" \
     "$(root_path "$UPDATER_PATH")" \
+    "$(root_path "$OLD_UPDATER_PATH")" \
     "$(root_path "$PORT_CONFIG_PATH")"
   systemctl daemon-reload
   apt remove -y home-energy-manager \

--- a/tests/scripts/proxmox-lxc.test.sh
+++ b/tests/scripts/proxmox-lxc.test.sh
@@ -287,7 +287,27 @@ assert_contains "assigns the persistent state directory" "StateDirectory=givener
 assert_contains "drops all Linux capabilities" "CapabilityBoundingSet=" "$SERVICE"
 assert_contains "does not grant ambient capabilities" "AmbientCapabilities=" "$SERVICE"
 assert_contains "enables service" "systemctl enable --now home-energy-manager.service" "$COMMANDS"
-assert_contains "installs update command" "yes" "$([ -x "$STAGE/root/usr/local/sbin/home-energy-manager-update" ] && echo yes || echo no)"
+assert_contains "installs update command" "yes" "$([ -x "$STAGE/root/usr/local/bin/update" ] && echo yes || echo no)"
+
+echo
+echo "3b. installer removes the legacy <v0.72.0 update command path"
+install -d -m 0755 "$STAGE/root/usr/local/sbin"
+: >"$STAGE/root/usr/local/sbin/home-energy-manager-update"
+chmod 0755 "$STAGE/root/usr/local/sbin/home-energy-manager-update"
+: >"$STAGE/commands.log"
+set +e
+PATH="$STAGE/bin:/usr/bin:/bin" \
+  HEM_TEST_LOG="$STAGE/commands.log" \
+  HEM_TEST_DEB="$STAGE/deb-fixture" \
+  HEM_TEST_DIGEST="$DIGEST" \
+  HEM_TEST_INSTALLED_VERSION="1.2.3" \
+  HEM_ROOT="$STAGE/root" \
+  HEM_PORT=7444 \
+  bash "$REPO_ROOT/scripts/proxmox/install.sh" >"$STAGE/legacy-output.log" 2>&1
+LEGACY_RC=$?
+set -e
+assert_eq "installer exits successfully" "0" "$LEGACY_RC"
+assert_contains "removes legacy update path" "no" "$([ -e "$STAGE/root/usr/local/sbin/home-energy-manager-update" ] && echo yes || echo no)"
 
 echo
 echo "4. update command is a no-op when the latest version is installed"
@@ -299,7 +319,7 @@ PATH="$STAGE/bin:/usr/bin:/bin" \
   HEM_TEST_DIGEST="$DIGEST" \
   HEM_TEST_INSTALLED_VERSION="1.2.3" \
   HEM_ROOT="$STAGE/root" \
-  bash "$STAGE/root/usr/local/sbin/home-energy-manager-update" >"$STAGE/update-output.log" 2>&1
+  bash "$STAGE/root/usr/local/bin/update" >"$STAGE/update-output.log" 2>&1
 UPDATE_RC=$?
 set -e
 UPDATE_COMMANDS="$(cat "$STAGE/commands.log")"
@@ -325,7 +345,7 @@ PATH="$STAGE/bin:/usr/bin:/bin" \
   HEM_TEST_DIGEST="$DIGEST" \
   HEM_TEST_INSTALLED_VERSION="1.2.2" \
   HEM_ROOT="$STAGE/root" \
-  bash "$STAGE/root/usr/local/sbin/home-energy-manager-update" >"$STAGE/upgrade-output.log" 2>&1
+  bash "$STAGE/root/usr/local/bin/update" >"$STAGE/upgrade-output.log" 2>&1
 UPGRADE_RC=$?
 set -e
 UPGRADE_COMMANDS="$(cat "$STAGE/commands.log")"
@@ -351,7 +371,7 @@ PATH="$STAGE/bin:/usr/bin:/bin" \
   HEM_TEST_HEALTH_FAIL_ONCE=1 \
   HEM_TEST_HEALTH_STATE="$STAGE/health-state" \
   HEM_ROOT="$STAGE/root" \
-  bash "$STAGE/root/usr/local/sbin/home-energy-manager-update" >"$STAGE/rollback-output.log" 2>&1
+  bash "$STAGE/root/usr/local/bin/update" >"$STAGE/rollback-output.log" 2>&1
 ROLLBACK_RC=$?
 set -e
 ROLLBACK_COMMANDS="$(cat "$STAGE/commands.log")"


### PR DESCRIPTION
Matches the community LXC script convention (tteck etc.) where the in-container updater is just `update` rather than a project-specific name.

The installer now installs `/usr/local/bin/update` instead of `/usr/local/sbin/home-energy-manager-update`. Existing users are migrated automatically — the installer removes the legacy path on the next run, even when they are already on the latest version.

`create-lxc.sh` prints `pct exec <id> -- update` and its `INSTALLER_SHA256` has been recalculated.

All 43 Proxmox LXC tests pass, including a new test (3b) that plants the legacy path and verifies it gets cleaned up.

Refs #246