### PR TITLE
fix(proxmox): install update command before already-installed early return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **The Proxmox LXC update command is now just `update`, matching other community helper scripts.** New containers use `pct exec <container-id> -- update` in place of `home-energy-manager-update`. Containers created before this change keep working as they are — the old command still updates the app. (issue #254)
+
 ## [0.71.6] - 2026-08-05
 
 ### Changed

--- a/scripts/proxmox/create-lxc.sh
+++ b/scripts/proxmox/create-lxc.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 
 REPO="psylsph/home-energy-manager"
 SCRIPT_REF="${HEM_SCRIPT_REF:-master}"
-INSTALLER_SHA256="d1f8de768552590faed009a8beb511ca29fb34b99c3317d64b4e28c9e4afa78e"
+INSTALLER_SHA256="341c49be7daa6a80ab38d4ccefd372fb41a4fd53d040d136cd6a0262ed2b16d6"
 CTID="${HEM_CTID:-}"
 HOSTNAME="${HEM_HOSTNAME:-home-energy-manager}"
 CORES="${HEM_CORES:-1}"

--- a/scripts/proxmox/install.sh
+++ b/scripts/proxmox/install.sh
@@ -8,7 +8,7 @@ DATA_DIR="/var/lib/givenergy-local"
 SERVICE_NAME="home-energy-manager.service"
 SERVICE_PATH="/etc/systemd/system/${SERVICE_NAME}"
 UPDATER_PATH="/usr/local/bin/update"
-# Legacy path from <v0.72.0; removed on upgrade so stale copies don't linger.
+# Legacy path from <v0.71.6; removed on upgrade so stale copies don't linger.
 OLD_UPDATER_PATH="/usr/local/sbin/home-energy-manager-update"
 PORT_CONFIG_PATH="/etc/default/home-energy-manager"
 
@@ -54,9 +54,17 @@ curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
 TAG="$(jq -er '.tag_name' "$RELEASE_JSON")" || fail "latest GitHub release has no tag"
 [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "unexpected release tag: $TAG"
 INSTALLED_VERSION="$(dpkg-query -W -f='${Version}' home-energy-manager 2>/dev/null || true)"
-# Remove the legacy <v0.72.0 updater path if it exists from a prior install.
+# Remove the legacy <v0.71.6 updater path if it exists from a prior install.
 if [ -e "$(root_path "$OLD_UPDATER_PATH")" ]; then
   rm -f "$(root_path "$OLD_UPDATER_PATH")"
+fi
+# Install or refresh the in-container `update` command before the
+# already-installed early return, so re-running a fresh installer on an
+# up-to-date container migrates the command name instead of only deleting the
+# legacy path and leaving no updater behind.
+install -d -m 0755 "$(dirname "$(root_path "$UPDATER_PATH")")"
+if [ "$(readlink -f "$0")" != "$(readlink -m "$(root_path "$UPDATER_PATH")")" ]; then
+  install -m 0755 "$0" "$(root_path "$UPDATER_PATH")"
 fi
 if [ "$INSTALLED_VERSION" = "${TAG#v}" ]; then
   systemctl enable --now "$SERVICE_NAME"
@@ -195,11 +203,6 @@ ReadWritePaths=$DATA_DIR
 [Install]
 WantedBy=multi-user.target
 EOF
-
-install -d -m 0755 "$(dirname "$(root_path "$UPDATER_PATH")")"
-if [ "$(readlink -f "$0")" != "$(readlink -m "$(root_path "$UPDATER_PATH")")" ]; then
-  install -m 0755 "$0" "$(root_path "$UPDATER_PATH")"
-fi
 
 systemctl daemon-reload
 systemctl enable --now "$SERVICE_NAME"

--- a/tests/scripts/proxmox-lxc.test.sh
+++ b/tests/scripts/proxmox-lxc.test.sh
@@ -310,6 +310,29 @@ assert_eq "installer exits successfully" "0" "$LEGACY_RC"
 assert_contains "removes legacy update path" "no" "$([ -e "$STAGE/root/usr/local/sbin/home-energy-manager-update" ] && echo yes || echo no)"
 
 echo
+echo "3c. migrating an up-to-date container installs the new update command"
+rm -f "$STAGE/root/usr/local/bin/update"
+install -d -m 0755 "$STAGE/root/usr/local/sbin"
+: >"$STAGE/root/usr/local/sbin/home-energy-manager-update"
+chmod 0755 "$STAGE/root/usr/local/sbin/home-energy-manager-update"
+: >"$STAGE/commands.log"
+set +e
+PATH="$STAGE/bin:/usr/bin:/bin" \
+  HEM_TEST_LOG="$STAGE/commands.log" \
+  HEM_TEST_DEB="$STAGE/deb-fixture" \
+  HEM_TEST_DIGEST="$DIGEST" \
+  HEM_TEST_INSTALLED_VERSION="1.2.3" \
+  HEM_ROOT="$STAGE/root" \
+  HEM_PORT=7444 \
+  bash "$REPO_ROOT/scripts/proxmox/install.sh" >"$STAGE/migrate-output.log" 2>&1
+MIGRATE_RC=$?
+set -e
+assert_eq "installer exits successfully" "0" "$MIGRATE_RC"
+assert_contains "removes legacy update path" "no" "$([ -e "$STAGE/root/usr/local/sbin/home-energy-manager-update" ] && echo yes || echo no)"
+assert_contains "installs the new update command" "yes" "$([ -x "$STAGE/root/usr/local/bin/update" ] && echo yes || echo no)"
+assert_not_contains "does not reinstall the package" "apt install -y /tmp/" "$(cat "$STAGE/commands.log")"
+
+echo
 echo "4. update command is a no-op when the latest version is installed"
 : >"$STAGE/commands.log"
 set +e


### PR DESCRIPTION
While investigating #254 I found a migration bug in the LXC installer.

`install.sh` removes the legacy `/usr/local/sbin/home-energy-manager-update` path before the "already installed" version check, but only installs the new `/usr/local/bin/update` at the very end of the script — after the early return. So re-running a fresh installer on a container that was already up to date deleted the old command and never created the new one, leaving the container with no update command at all.

This moves the self-install of the `update` command to before the version check, so both the early-return and full-install paths install it. It also refreshes the `INSTALLER_SHA256` pin in `create-lxc.sh` (integrity-coupled to `install.sh`), adds a regression test (verified to fail without the fix), and adds the changelog entry for the rename that shipped undocumented in v0.71.6.

Refs #254